### PR TITLE
Fix missing import in orchestrator

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -18,6 +18,7 @@ import json
 import random
 from datetime import datetime
 import traceback
+import sys
 from typing import Any, Dict, Tuple, Sequence, Optional
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- ensure `sys` is imported at module level for orchestrator

## Testing
- `python -m py_compile orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_b_684a81197c788332be48920250220c69