### PR TITLE
Add TODO detailing setup errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+# TODO
+
+## Observed Errors
+
+1. `python orchestrator.py --help` fails due to missing module `pandas`.
+2. `make test` fails at `setup.sh` because it tries to activate `env-as`, which is not created.
+
+## Action Items
+
+- Update environment setup to ensure required Python packages (e.g., pandas) are installed before running the orchestrator.
+- Modify `setup.sh` to either create `env-as` or skip the activation test if it is not needed.
+


### PR DESCRIPTION
## Summary
- document observed errors when running the code

## Testing
- `python orchestrator.py --help` *(fails: No module named 'pandas')*
- `make test` *(fails: env-as/bin/activate missing)*

------
https://chatgpt.com/codex/tasks/task_b_684a834c28548332a24e95779bfff159