### PR TITLE
Fix environment setup and doc instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
 ./setup.sh
 ```
 
-This automatically creates Python environments, installs all dependencies, and sets up the project structure.
+This automatically creates Python environments, installs all dependencies, and sets up the project structure. If you prefer to manage the environment yourself, install the required packages first:
+
+```bash
+pip install -r requirements.txt
+```
+This step ensures modules like `pandas` are available before running `orchestrator.py`.
 
 ## Git Repository Structure
 

--- a/setup.sh
+++ b/setup.sh
@@ -114,30 +114,15 @@ create_environments() {
 # Install dependencies in env-tpa
 install_env_tpa_deps() {
     log_info "Installing dependencies in env-tpa..."
-    
+
     source env-tpa/bin/activate
-    
+
     # Upgrade pip first
     pip install --upgrade pip
-    
-    # Install base scientific computing stack
-    log_info "Installing base scientific packages..."
-    pip install numpy scipy scikit-learn pandas matplotlib seaborn
-    
-    # Install TPOT (no special handling needed since we support only Python 3.11)
-    log_info "Installing TPOT..."
-    pip install tpot
-    
-    # Install AutoGluon – fully supported on Python 3.11
-    log_info "Installing AutoGluon..."
-    pip install autogluon.tabular
-    
-    # Install additional utilities
-    pip install rich joblib
-    
-    # Install XGBoost and LightGBM
-    pip install xgboost lightgbm
-    
+
+    # Install all Python dependencies from requirements.txt
+    pip install -r requirements.txt
+
     deactivate
     log_success "env-tpa dependencies installed successfully"
 }
@@ -162,12 +147,13 @@ create_directories() {
 test_environments() {
     log_info "Testing environment installations..."
     
-    # Test env-as
-    log_info "Testing env-as environment..."
-    source env-as/bin/activate
-    
-    if [[ "$PYTHON_CMD" == "python3.13" ]]; then
-        python -c "
+    # Test env-as only if it exists
+    if [ -d "env-as" ]; then
+        log_info "Testing env-as environment..."
+        source env-as/bin/activate
+
+        if [[ "$PYTHON_CMD" == "python3.13" ]]; then
+            python -c "
 import sklearn
 import numpy as np
 import pandas as pd
@@ -176,8 +162,8 @@ print(f'  - Scikit-learn version: {sklearn.__version__}')
 print(f'  - NumPy version: {np.__version__}')
 print(f'  - Pandas version: {pd.__version__}')
 "
-    else
-        python -c "
+        else
+            python -c "
 import auto_sklearn.regression
 import sklearn
 import numpy as np
@@ -188,8 +174,11 @@ print(f'  - Scikit-learn version: {sklearn.__version__}')
 print(f'  - NumPy version: {np.__version__}')
 print(f'  - Pandas version: {pd.__version__}')
 "
+        fi
+        deactivate
+    else
+        log_warning "env-as environment not found. Skipping Auto-Sklearn test."
     fi
-    deactivate
     
     # Test env-tpa
     log_info "Testing env-tpa environment..."


### PR DESCRIPTION
## Summary
- document requirements installation in README
- install python dependencies via requirements.txt
- skip env-as tests if env not present

## Testing
- `python orchestrator.py --help` *(fails: ModuleNotFoundError: No module named 'rich')*
- `make test` *(fails to finish due to dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_b_684a84ce5b748332b12fc79eeb6183bf