### PR TITLE
Add Docker support for persistent log storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "orchestrator.py", "--help"]

--- a/README.md
+++ b/README.md
@@ -119,4 +119,23 @@ All runs generate artifacts in `05_outputs/<dataset_name>/`:
 - Linux (recommended) or macOS
 - Python 3.11+ (recommended) or Python 3.13 (with limitations)
 - 8GB+ RAM for larger datasets
-- Build tools (`build-essential` on Ubuntu, `base-devel` on Arch) 
+- Build tools (`build-essential` on Ubuntu, `base-devel` on Arch)
+
+## Running in Docker with Persistent Logs
+
+This repository includes a minimal **Dockerfile** and a
+`docker-compose.yml` for reproducible runs. The compose configuration
+mounts the host `05_outputs/` directory into the container so that
+all logs and artifacts remain available after the container exits.
+
+```bash
+# Build the Docker image
+docker compose build
+
+# Execute the orchestrator (logs are written to ./05_outputs on the host)
+docker compose run automl \
+  python orchestrator.py --help
+```
+
+All logs are stored under `05_outputs/logs/` on the host machine,
+ensuring they persist between runs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  automl:
+    build: .
+    volumes:
+      - ./DataSets:/app/DataSets:ro
+      - ./05_outputs:/app/05_outputs
+    command: ["python", "orchestrator.py", "--help"]


### PR DESCRIPTION
## Summary
- add Dockerfile for container execution
- add docker-compose.yml that mounts `05_outputs` for log persistence
- document Docker usage and volume persistence in README

## Testing
- `make test` *(fails: env-as/bin/activate missing)*

------
https://chatgpt.com/codex/tasks/task_b_684a861b0cc0833288377946966a08e9