### PR TITLE
Redact dataset paths in orchestrator logs

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -566,8 +566,8 @@ def _cli() -> None:
         sys.exit(2) # Exit code for data loading error
 
     logger.info("Starting AutoML meta-search...")
-    logger.info("Predictors path: %s", args.data)
-    logger.info("Target path: %s", args.target)
+    logger.info("Predictors file: %s", Path(args.data).name)
+    logger.info("Target file: %s", Path(args.target).name)
     logger.info("Time limit per engine: %d seconds", args.time)
     logger.info("Output directory: %s", run_dir)
     logger.info("Evaluation metric: %s", args.metric)


### PR DESCRIPTION
## Summary
- avoid logging full dataset paths in orchestrator

## Testing
- `make test` *(fails: env-as/bin/activate missing)*

------
https://chatgpt.com/codex/tasks/task_b_684a86236d908332be358e2e40cb53ad