### PR TITLE
Add ELK-based log aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,20 @@ All runs generate artifacts in `05_outputs/<dataset_name>/`:
 - Python 3.11+ (recommended) or Python 3.13 (with limitations)
 - 8GB+ RAM for larger datasets
 - Build tools (`build-essential` on Ubuntu, `base-devel` on Arch) 
+## Log Aggregation
+
+This project ships a simple **ELK stack** configuration for collecting and searching logs.
+Start the stack with:
+
+```bash
+docker compose -f docker-compose.logging.yml up -d
+```
+
+Set the `LOGSTASH_HOST` environment variable so `orchestrator.py` forwards logs to Logstash:
+
+```bash
+export LOGSTASH_HOST=localhost  # or the host running Logstash
+export LOGSTASH_PORT=5959       # optional, defaults to 5959
+```
+
+Now run the orchestrator as usual and view logs in Kibana at <http://localhost:5601>.

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,33 @@
+version: '3.7'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+    environment:
+      - discovery.type=single-node
+    ports:
+      - '9200:9200'
+    networks:
+      - elk
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.12.2
+    volumes:
+      - ./logstash.conf:/usr/share/logstash/pipeline/logstash.conf:ro
+    ports:
+      - '5959:5959'
+    depends_on:
+      - elasticsearch
+    networks:
+      - elk
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.12.2
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - '5601:5601'
+    depends_on:
+      - elasticsearch
+    networks:
+      - elk
+networks:
+  elk:
+    driver: bridge

--- a/logstash.conf
+++ b/logstash.conf
@@ -1,0 +1,13 @@
+input {
+  tcp {
+    port => 5959
+    codec => json_lines
+  }
+}
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "automl-logs-%{+YYYY.MM.dd}"
+  }
+  stdout { codec => rubydebug }
+}

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -62,6 +62,21 @@ if "AUTOML_VERBOSE" in os.environ:
 logging.basicConfig(level=logging_level, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+# Optional Logstash integration for centralized logging
+if os.getenv("LOGSTASH_HOST"):
+    try:
+        from logstash_async.handler import AsynchronousLogstashHandler
+        from logstash_async.formatter import LogstashFormatter
+
+        ls_host = os.environ.get("LOGSTASH_HOST")
+        ls_port = int(os.environ.get("LOGSTASH_PORT", "5959"))
+        ls_handler = AsynchronousLogstashHandler(ls_host, ls_port, database_path=None)
+        ls_handler.setFormatter(LogstashFormatter())
+        logging.getLogger().addHandler(ls_handler)
+        logger.info("Logging to Logstash at %s:%s", ls_host, ls_port)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not configure Logstash handler: %s", exc)
+
 # ---------------------------------------------------------------------------
 # Reproducibility – set global seeds immediately at import-time
 # ---------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ scipy==1.11.4
 autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
-lightgbm==4.3.0 
+lightgbm==4.3.0
+python-logstash-async==2.9.0


### PR DESCRIPTION
## Summary
- add optional Logstash logging in `orchestrator.py`
- provide docker-compose stack for Elastic, Logstash, Kibana
- include Logstash pipeline config
- document how to enable centralized logging
- require `python-logstash-async` dependency

## Testing
- `make test` *(fails: env-as/bin/activate: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684a8626df84833295ef0fea88524ca9