### PR TITLE
Add Parquet dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ deactivate
 
 ## Running the Orchestrator
 
+Datasets may be provided as CSV or Parquet files. Loading Parquet requires the
+optional ``pyarrow`` or ``fastparquet`` package.
+
 ```bash
 # Activate the appropriate environment
 ./activate-tpa.sh

--- a/scripts/data_loader.py
+++ b/scripts/data_loader.py
@@ -4,6 +4,18 @@ from pathlib import Path
 from typing import Tuple
 
 import pandas as pd
+import importlib.util
+
+
+def _ensure_parquet_engine() -> None:
+    """Ensure that a Parquet engine is available."""
+    if (
+        importlib.util.find_spec("pyarrow") is None
+        and importlib.util.find_spec("fastparquet") is None
+    ):
+        raise ImportError(
+            "Loading Parquet files requires either 'pyarrow' or 'fastparquet'."
+        )
 
 def load_data(
     predictors_path: str | Path,
@@ -12,8 +24,8 @@ def load_data(
 ) -> Tuple[pd.DataFrame, pd.Series]:
     """Load predictor and target data from specified paths.
 
-    Supports CSV and conceptually, Parquet files. For Parquet, it's a placeholder
-    and would require `pyarrow` or `fastparquet`.
+    Supports CSV and Parquet files. Parquet requires either ``pyarrow`` or
+    ``fastparquet`` to be installed.
 
     Parameters
     ----------
@@ -46,19 +58,19 @@ def load_data(
 
     if predictors_path.suffix == ".csv":
         X = pd.read_csv(predictors_path, **kwargs)
-    # elif predictors_path.suffix == ".parquet":
-    #     # Placeholder for Parquet support
-    #     # X = pd.read_parquet(predictors_path, **kwargs)
-    #     raise ValueError("Parquet support is not yet implemented.")
+    elif predictors_path.suffix == ".parquet":
+        _ensure_parquet_engine()
+        X = pd.read_parquet(predictors_path, **kwargs)
     else:
-        raise ValueError(f"Unsupported predictors file format: {predictors_path.suffix}")
+        raise ValueError(
+            f"Unsupported predictors file format: {predictors_path.suffix}"
+        )
 
     if target_path.suffix == ".csv":
         y = pd.read_csv(target_path, **kwargs).squeeze()
-    # elif target_path.suffix == ".parquet":
-    #     # Placeholder for Parquet support
-    #     # y = pd.read_parquet(target_path, **kwargs).squeeze()
-    #     raise ValueError("Parquet support is not yet implemented.")
+    elif target_path.suffix == ".parquet":
+        _ensure_parquet_engine()
+        y = pd.read_parquet(target_path, **kwargs).squeeze()
     else:
         raise ValueError(f"Unsupported target file format: {target_path.suffix}")
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+import sys
+from pathlib import Path as _Path
+
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from scripts.data_loader import load_data
+
+
+def test_load_csv(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    target = pd.Series([0, 1], name='target')
+    csv_x = tmp_path / 'X.csv'
+    csv_y = tmp_path / 'y.csv'
+    df.to_csv(csv_x, index=False)
+    target.to_csv(csv_y, index=False, header=True)
+
+    X, y = load_data(csv_x, csv_y)
+    pd.testing.assert_frame_equal(X, df)
+    pd.testing.assert_series_equal(y, target)
+
+
+def test_load_parquet(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    target = pd.Series([0, 1], name='target')
+    pq_x = tmp_path / 'X.parquet'
+    pq_y = tmp_path / 'y.parquet'
+    df.to_parquet(pq_x)
+    target.to_frame().to_parquet(pq_y)
+
+    X, y = load_data(pq_x, pq_y)
+    pd.testing.assert_frame_equal(X, df)
+    pd.testing.assert_series_equal(y, target)
+
+
+def test_missing_parquet_engine(monkeypatch, tmp_path):
+    df = pd.DataFrame({'a': [1]})
+    pq_x = tmp_path / 'x.parquet'
+    pq_y = tmp_path / 'y.parquet'
+    df.to_parquet(pq_x)
+    df.to_parquet(pq_y)
+
+    monkeypatch.setattr('importlib.util.find_spec', lambda name: None)
+    with pytest.raises(ImportError):
+        load_data(pq_x, pq_y)
+


### PR DESCRIPTION
## Summary
- support Parquet datasets in `load_data`
- clarify Parquet support in README
- add unit tests for csv and parquet loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a864f3ff883328390328628481abe