### PR TITLE
Add AutoGluon install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ pip install -r requirements.txt
 ```
 This step ensures modules like `pandas` are available before running `orchestrator.py`.
 
+> **Note**
+> 
+> The AutoGluon engine depends on the `autogluon.tabular` package. If this library is missing, `autogluon_wrapper.py` falls back to a simple `LinearRegression`, which severely limits model quality. Run `./setup.sh` or the `pip install` command above to install the full AutoGluon dependencies and avoid the fallback.
+
 ## Git Repository Structure
 
 This repository has three main branches:


### PR DESCRIPTION
## Summary
- warn that AutoGluon wrapper falls back to LinearRegression if `autogluon.tabular` is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bc9a432108332baa72bd88459f180