### PR TITLE
Restore auto-sklearn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ python3.11 -m venv env-tpa
 # Install Auto-Sklearn environment
 source env-as/bin/activate
 pip install --upgrade pip
-pip install auto-sklearn==0.15.0 numpy==1.24.3 scikit-learn==1.3.2 pandas matplotlib seaborn rich joblib
+pip install --prefer-binary auto-sklearn scikit-learn pandas
 deactivate
 
 # Install TPOT + AutoGluon environment
 source env-tpa/bin/activate
 pip install --upgrade pip
-pip install setuptools tpot autogluon.tabular numpy scikit-learn pandas matplotlib seaborn rich joblib xgboost lightgbm
+pip install --prefer-binary setuptools tpot autogluon.tabular numpy scikit-learn pandas matplotlib seaborn rich joblib xgboost lightgbm
 deactivate
 ```
 
@@ -143,7 +143,6 @@ export LOGSTASH_PORT=5959       # optional, defaults to 5959
 ```
 
 Now run the orchestrator as usual and view logs in Kibana at <http://localhost:5601>.
-=======
 - Build tools (`build-essential` on Ubuntu, `base-devel` on Arch)
 
 ## Running in Docker with Persistent Logs
@@ -164,7 +163,6 @@ docker compose run automl \
 
 All logs are stored under `05_outputs/logs/` on the host machine,
 ensuring they persist between runs.
-=======
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/activate-as.sh
+++ b/activate-as.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 # Activate Auto-Sklearn environment
 
-# Ensure pyenv is initialized
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-
 echo "Activating Auto-Sklearn environment (env-as)..."
-pyenv activate env-as
+source env-as/bin/activate
 echo "✓ Auto-Sklearn environment activated"
-echo "Use 'pyenv deactivate' to exit the environment"
+echo "Use 'deactivate' to exit the environment"

--- a/setup.sh
+++ b/setup.sh
@@ -98,17 +98,40 @@ setup_pyenv() {
 # Create virtual environments
 create_environments() {
     log_info "Creating Python virtual environments..."
-    
+
     # Use the Python command determined in check_system
-    
-    # Create env-tpa (TPOT + AutoGluon environment)  
+
+    # Create env-as (Auto-Sklearn environment)
+    if [ -d "env-as" ]; then
+        log_info "Removing existing env-as environment..."
+        rm -rf env-as
+    fi
+    log_info "Creating env-as (Auto-Sklearn environment)..."
+    $PYTHON_CMD -m venv env-as
+    log_success "Created env-as environment"
+
+    # Create env-tpa (TPOT + AutoGluon environment)
     if [ -d "env-tpa" ]; then
         log_info "Removing existing env-tpa environment..."
         rm -rf env-tpa
     fi
     log_info "Creating env-tpa (TPOT + AutoGluon environment)..."
     $PYTHON_CMD -m venv env-tpa
-    log_success "Created env-tpa environment"
+log_success "Created env-tpa environment"
+}
+
+# Install dependencies in env-as
+install_env_as_deps() {
+    log_info "Installing dependencies in env-as..."
+
+    source env-as/bin/activate
+    pip install --upgrade pip
+
+    log_info "Installing auto-sklearn and dependencies..."
+    pip install --prefer-binary auto-sklearn scikit-learn pandas
+
+    deactivate
+    log_success "env-as dependencies installed successfully"
 }
 
 # Install dependencies in env-tpa
@@ -121,7 +144,7 @@ install_env_tpa_deps() {
     pip install --upgrade pip
 
     # Install all Python dependencies from requirements.txt
-    pip install -r requirements.txt
+    pip install --prefer-binary -r requirements.txt
 
     deactivate
     log_success "env-tpa dependencies installed successfully"
@@ -270,15 +293,15 @@ create_activation_scripts() {
     log_info "Creating environment activation scripts..."
     
     # Create activate-as.sh
-    # cat > activate-as.sh << 'EOF'
-    # #!/bin/bash
-    # # Activate Auto-Sklearn environment
-    # echo "Activating Auto-Sklearn environment (env-as)..."
-    # source env-as/bin/activate
-    # echo "✓ Auto-Sklearn environment activated"
-    # echo "Use 'deactivate' to exit the environment"
-    # EOF
-    # chmod +x activate-as.sh
+    cat > activate-as.sh << 'EOF'
+#!/bin/bash
+# Activate Auto-Sklearn environment
+echo "Activating Auto-Sklearn environment (env-as)..."
+source env-as/bin/activate
+echo "✓ Auto-Sklearn environment activated"
+echo "Use 'deactivate' to exit the environment"
+EOF
+    chmod +x activate-as.sh
     
     # Create activate-tpa.sh  
     cat > activate-tpa.sh << 'EOF'
@@ -306,6 +329,7 @@ main() {
     # setup_pyenv  # Commented out to use system Python directly
     create_directories
     create_environments
+    install_env_as_deps
     install_env_tpa_deps
     test_environments
     post_setup_check
@@ -317,6 +341,7 @@ main() {
     echo "=========================================="
     echo ""
     echo "Environment Usage:"
+    echo "  • Auto-Sklearn:      ./activate-as.sh"
     echo "  • TPOT + AutoGluon: ./activate-tpa.sh"
     echo ""
     echo "Quick Start:"


### PR DESCRIPTION
## Summary
- restore creation of `env-as` and install a modern auto-sklearn
- prefer binary wheels for all dependency installs
- add activation script for the Auto-Sklearn environment
- clean up README instructions and merge markers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bd0b91a2c8332808bbc5d6f28db53