### PR TITLE
Fix README orchestrator instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,13 @@ deactivate
 # Activate the appropriate environment
 ./activate-tpa.sh
 
-# Run with all engines
+# Run with all engines (default behavior)
 python orchestrator.py --all --time 3600 \
   --data DataSets/3/predictors_Hold\ 1\ Full_20250527_151252.csv \
   --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv
 
-# Run with specific engines
-python orchestrator.py --tpot --time 1800 \
-  --data DataSets/1/Predictors_Hold-1_2025-04-14_18-28.csv
-
+# The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
+# together. The `--all` flag is optional but included here for clarity.
 deactivate
 ```
 


### PR DESCRIPTION
## Summary
- update orchestrator usage instructions
- remove single-engine example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684bd6350c148332970082bb994bc0c1