### PR TITLE
Switch to auto-sklearn2

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python3.11 -m venv env-tpa
 # Install Auto-Sklearn environment (Python <=3.10 only)
 source env-as/bin/activate
 pip install --upgrade pip
-pip install auto-sklearn==0.15.0 numpy==1.24.3 scikit-learn==1.4.2 pandas matplotlib seaborn rich joblib
+pip install auto-sklearn2 numpy==1.24.3 scikit-learn==1.4.2 pandas matplotlib seaborn rich joblib
 deactivate
 
 # Install TPOT + AutoGluon environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ rich==13.7.0
 pandas==2.2.1
 joblib==1.3.2
 scikit-learn==1.4.2
-auto-sklearn==0.15.0
+auto-sklearn2
 tpot==0.12.2
 scipy==1.11.4
 autogluon.tabular[all]==1.3.1

--- a/scripts/run_autosklearn.py
+++ b/scripts/run_autosklearn.py
@@ -2,7 +2,7 @@
 """Auto-Sklearn Runner (Python 3.9 – env-as)
 
 This script is meant to be executed from the *env-as* pyenv virtual
-environment.  It expects that `auto-sklearn==0.15.0` along with its
+environment.  It expects that `auto-sklearn2` along with its
 supported dependency stack (NumPy, SciPy, scikit-learn 0.24.x, …) is
 available.
 


### PR DESCRIPTION
## Summary
- update manual instructions to install `auto-sklearn2`
- note that `run_autosklearn.py` expects `auto-sklearn2`
- replace dependency in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bd66f18308332aa04314ee1d5bf9c