### PR TITLE
Force orchestrator to use all engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,10 @@ deactivate
 # Activate the appropriate environment
 ./activate-tpa.sh
 
-# Run with all engines
-python orchestrator.py --all --time 3600 \
+# Run the orchestrator (all engines are used automatically)
+python orchestrator.py --time 3600 \
   --data DataSets/3/predictors_Hold\ 1\ Full_20250527_151252.csv \
   --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv
-
-# Run with specific engines
-python orchestrator.py --tpot --time 1800 \
-  --data DataSets/1/Predictors_Hold-1_2025-04-14_18-28.csv
 
 deactivate
 ```

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -679,22 +679,22 @@ def _cli() -> None:
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Run all available AutoML engines",
+        help="[Ignored] All orchestrations run with every engine",
     )
     parser.add_argument(
         "--autogluon",
         action="store_true",
-        help="Run only the AutoGluon engine",
+        help="[Ignored] Autogluon always runs",
     )
     parser.add_argument(
         "--autosklearn",
         action="store_true",
-        help="Run only the Auto-Sklearn engine",
+        help="[Ignored] Auto-Sklearn always runs",
     )
     parser.add_argument(
         "--tpot",
         action="store_true",
-        help="Run only the TPOT engine",
+        help="[Ignored] TPOT always runs",
     )
     parser.add_argument(
         "--no-ensemble",
@@ -704,22 +704,8 @@ def _cli() -> None:
 
     args = parser.parse_args()
 
-    if not (args.all or args.autogluon or args.autosklearn or args.tpot):
-        parser.error("At least one engine must be selected: --all, --autogluon, --autosklearn, or --tpot")
-
-    selected_engines = []
-    if args.all:
-        selected_engines = ["autogluon", "autosklearn", "tpot"]
-    else:
-        if args.autogluon:
-            selected_engines.append("autogluon")
-        if args.autosklearn:
-            selected_engines.append("autosklearn")
-        if args.tpot:
-            selected_engines.append("tpot")
-
-    if not selected_engines:
-        parser.error("No engines selected. Please use --all or specify at least one engine with --autogluon, --autosklearn, or --tpot.")
+    # Regardless of the provided flags, always use all engines
+    selected_engines = ["autogluon", "autosklearn", "tpot"]
 
     # Define unique run directory for artifacts
     timestamp_str = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/setup.sh
+++ b/setup.sh
@@ -405,7 +405,7 @@ main() {
     echo ""
     echo "Quick Start:"
     echo "  1. Run: ./activate-tpa.sh"
-    echo "  2. Test: python orchestrator.py --all --time 300 --data DataSets/3/predictors_Hold\\ 1\\ Full_20250527_151252.csv --target DataSets/3/targets_Hold\\ 1\\ Full_20250527_151252.csv"
+    echo "  2. Test: python orchestrator.py --time 300 --data DataSets/3/predictors_Hold\\ 1\\ Full_20250527_151252.csv --target DataSets/3/targets_Hold\\ 1\\ Full_20250527_151252.csv"
     echo "  3. Optionally try Auto-Sklearn with ./activate-as.sh"
     echo ""
     echo "For more information, see README.md"


### PR DESCRIPTION
## Summary
- ignore engine selection flags in `orchestrator.py`
- update README usage example to reflect default engine set
- tweak setup script quick-start message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bd6700cf4833298ca9bdaee0e0db5