### PR TITLE
Add component validation and tests

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -57,9 +57,22 @@ RANDOM_STATE = 42
 N_SPLITS_CROSS_VALIDATION = 5
 N_REPEATS_CROSS_VALIDATION = 3
 
-# TODO: Define these more rigorously based on approved model families and preprocessors
-# MODEL_FAMILIES = ["linear", "tree", "ensemble", "neural_network", "svm"]
-# PREP_STEPS = ["scalers", "dimensionality", "outliers"]
+# ---------------------------------------------------------------------------
+# Component Discovery
+# ---------------------------------------------------------------------------
+# Build lists of available model families and preprocessing steps by inspecting
+# the modules under ``components/models`` and ``components/preprocessors``.
+_MODELS_DIR = Path(__file__).parent / "components" / "models"
+_PREPROCESSORS_DIR = Path(__file__).parent / "components" / "preprocessors"
+
+# Names correspond to the module file stems without the ``.py`` extension.
+MODEL_FAMILIES = sorted(
+    p.stem for p in _MODELS_DIR.glob("*.py") if p.stem != "__init__"
+)
+
+PREP_STEPS = sorted(
+    p.stem for p in _PREPROCESSORS_DIR.rglob("*.py") if p.stem != "__init__"
+)
 
 # Wallclock limit for each engine, in seconds. This is a default and can be overridden by CLI.
 WALLCLOCK_LIMIT_SEC = 3600  # 1 hour
@@ -639,12 +652,22 @@ def _score(
 
 
 def _validate_components_availability() -> None:
-    """Validates that all required components (preprocessors, models) are available.
-    (Placeholder - not fully implemented yet)
-    """
-    logger.info("Validating components availability... (Not fully implemented)")
-    # TODO: Implement actual validation logic to ensure all specified components
-    # in MODEL_FAMILIES and PREP_STEPS exist in the components/ directory.
+    """Ensure that all component names correspond to actual module files."""
+    missing: list[str] = []
+
+    for name in MODEL_FAMILIES:
+        if not (_MODELS_DIR / f"{name}.py").is_file():
+            missing.append(f"model '{name}'")
+
+    for name in PREP_STEPS:
+        pattern = list(_PREPROCESSORS_DIR.rglob(f"{name}.py"))
+        if not pattern:
+            missing.append(f"preprocessor '{name}'")
+
+    if missing:
+        raise FileNotFoundError(
+            "Missing components: " + ", ".join(sorted(missing))
+        )
 
 def _cli() -> None:
     """Parses command-line arguments and orchestrates the AutoML pipeline."""
@@ -703,6 +726,12 @@ def _cli() -> None:
     )
 
     args = parser.parse_args()
+
+    try:
+        _validate_components_availability()
+    except FileNotFoundError as exc:
+        logger.error(str(exc))
+        sys.exit(1)
 
     if not (args.all or args.autogluon or args.autosklearn or args.tpot):
         parser.error("At least one engine must be selected: --all, --autogluon, --autosklearn, or --tpot")

--- a/tests/test_component_validation.py
+++ b/tests/test_component_validation.py
@@ -1,0 +1,77 @@
+import importlib
+import importlib.util
+import os
+import types
+import sys
+import pytest
+
+
+def load_orchestrator(monkeypatch):
+    # Stub heavy dependencies so orchestrator can be imported
+    stub_names = [
+        'pandas',
+        'numpy',
+        'sklearn',
+        'sklearn.pipeline',
+        'sklearn.model_selection',
+        'sklearn.metrics',
+        'rich',
+        'rich.console',
+        'rich.tree',
+        'scripts',
+        'scripts.data_loader',
+        'engines',
+        'engines.auto_sklearn_wrapper',
+        'engines.tpot_wrapper',
+        'engines.autogluon_wrapper',
+    ]
+    for name in stub_names:
+        module = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    # populate minimal attributes used at import time
+    sys.modules['numpy'].random = types.SimpleNamespace(seed=lambda *a, **k: None)
+    sys.modules['rich.console'].Console = type('Console', (), {'__init__': lambda self, *a, **k: None, 'log': lambda *a, **k: None})
+    sys.modules['rich.tree'].Tree = type('Tree', (), {})
+    dl_mod = sys.modules['scripts.data_loader']
+    def load_data(*args, **kwargs):
+        return None, None
+    dl_mod.load_data = load_data
+    sys.modules['engines'].discover_available = lambda: []
+    sys.modules['engines.auto_sklearn_wrapper'].AutoSklearnEngine = object
+    sys.modules['engines.tpot_wrapper'].TPOTEngine = object
+    sys.modules['engines.autogluon_wrapper'].AutoGluonEngine = object
+    sys.modules['sklearn.pipeline'].Pipeline = object
+    sys.modules['sklearn.model_selection'].RepeatedKFold = object
+    sys.modules['sklearn.model_selection'].cross_validate = lambda *a, **k: None
+    metrics_mod = sys.modules['sklearn.metrics']
+    metrics_mod.make_scorer = lambda *a, **k: None
+    metrics_mod.mean_absolute_error = lambda *a, **k: None
+    metrics_mod.mean_squared_error = lambda *a, **k: None
+    metrics_mod.r2_score = lambda *a, **k: None
+
+    # Load orchestrator module directly from file path to avoid import issues
+    spec = importlib.util.spec_from_file_location(
+        'orchestrator',
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), 'orchestrator.py'),
+    )
+    orchestrator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(orchestrator)
+    return orchestrator
+
+
+def test_validate_components_success(monkeypatch):
+    orch = load_orchestrator(monkeypatch)
+    orch._validate_components_availability()
+
+
+def test_validate_components_failure(monkeypatch):
+    orch = load_orchestrator(monkeypatch)
+    monkeypatch.setattr(
+        orch,
+        'MODEL_FAMILIES',
+        orch.MODEL_FAMILIES + ['FakeModel'],
+        raising=False,
+    )
+    with pytest.raises(FileNotFoundError):
+        orch._validate_components_availability()


### PR DESCRIPTION
## Summary
- auto-discover available model families and preprocessing steps in orchestrator
- implement `_validate_components_availability` to ensure modules exist
- call component validation early in `_cli`
- add unit tests covering validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bd701af1083329d0b23a9a1b1ae38