### PR TITLE
Improve Python 3.11 setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ./setup.sh [--with-as]
 ```
 
-This automatically creates the `env-tpa` Python environment, installs all dependencies (including `pandas`), and sets up the project structure. Use `--with-as` if you also want the optional Auto-Sklearn environment. After running it, activate the environment before using the orchestrator:
+This automatically creates the `env-tpa` Python environment, installs all dependencies (including `pandas`), and sets up the project structure. On **Python&nbsp;3.11 or higher**, `setup.sh` skips Auto-Sklearn automatically, so only the TPOT/AutoGluon environment is prepared. Use `--with-as` on Python&nbsp;≤3.10 if you also want the optional Auto-Sklearn environment. After running it, activate the environment before using the orchestrator:
 
 ```bash
 ./activate-tpa.sh


### PR DESCRIPTION
## Summary
- document automatic Auto-Sklearn skipping on Python 3.11+

## Testing
- `pytest -q`
- `python orchestrator.py --all --time 10 --data DataSets/1/D1-Predictors.csv --target DataSets/1/D1-Targets.csv` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684be43300348332a6948080eeb00b91