### PR TITLE
Fix setup install order and py3.11 compatibility

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -139,7 +139,13 @@ install_env_tpa_deps() {
     pip install --upgrade pip
 
     # Install all Python dependencies from requirements.txt using wheels only
-    pip install --only-binary=:all: -r requirements.txt
+    if [[ "$PYTHON_CMD" == *"3.11"* ]]; then
+        grep -v '^auto-sklearn' requirements.txt > /tmp/requirements_no_as.txt
+        pip install --only-binary=:all: -r /tmp/requirements_no_as.txt
+        rm /tmp/requirements_no_as.txt
+    else
+        pip install --only-binary=:all: -r requirements.txt
+    fi
 
     deactivate
     log_success "env-tpa dependencies installed successfully"
@@ -159,8 +165,8 @@ install_env_as_deps() {
     # Upgrade pip first
     pip install --upgrade pip
 
-    if [ "$PYTHON_MINOR" -ge 11 ]; then
-        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python $PYTHON_MINOR; installing base stack only"
+    if [[ "$PYTHON_CMD" == *"3.11"* ]]; then
+        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python 3.11; installing base stack only"
         pip install --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
     else
         pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
@@ -379,10 +385,10 @@ main() {
     # setup_pyenv  # Commented out to use system Python directly
     create_directories
     create_environments
-    install_env_tpa_deps
     if [ "$ENABLE_AS" = true ]; then
         install_env_as_deps
     fi
+    install_env_tpa_deps
     test_environments
     post_setup_check
     create_activation_scripts


### PR DESCRIPTION
## Summary
- avoid installing auto-sklearn when Python 3.11 is detected
- skip auto-sklearn in env-tpa dependencies on Python 3.11
- call `install_env_as_deps` before `install_env_tpa_deps`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684be43b7fa08332b45531681e40b415