### PR TITLE
Fix install order and deduplicate env-as setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -159,8 +159,8 @@ install_env_as_deps() {
     # Upgrade pip first
     pip install --upgrade pip
 
-    if [ "$PYTHON_MINOR" -ge 11 ]; then
-        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python $PYTHON_MINOR; installing base stack only"
+    if [[ "$PYTHON_CMD" == *"3.11"* ]]; then
+        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python 3.11; installing base stack only"
         pip install --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
     else
         pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
@@ -379,10 +379,10 @@ main() {
     # setup_pyenv  # Commented out to use system Python directly
     create_directories
     create_environments
-    install_env_tpa_deps
     if [ "$ENABLE_AS" = true ]; then
         install_env_as_deps
     fi
+    install_env_tpa_deps
     test_environments
     post_setup_check
     create_activation_scripts


### PR DESCRIPTION
## Summary
- ensure the Auto-Sklearn environment only installs when Python 3.11 isn't used
- call `install_env_as_deps` before installing env-tpa dependencies

## Testing
- `pytest -q`
- `bash setup.sh --quiet` *(fails: Could not find a version that satisfies the requirement auto-sklearn==0.15.0)*

------
https://chatgpt.com/codex/tasks/task_b_684be44425d48332b2c4a37e38116adc