### PR TITLE
Fix env deps order

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -379,10 +379,10 @@ main() {
     # setup_pyenv  # Commented out to use system Python directly
     create_directories
     create_environments
-    install_env_tpa_deps
     if [ "$ENABLE_AS" = true ]; then
         install_env_as_deps
     fi
+    install_env_tpa_deps
     test_environments
     post_setup_check
     create_activation_scripts


### PR DESCRIPTION
## Summary
- reorder `install_env_as_deps` call ahead of `install_env_tpa_deps`
- keep single `install_env_as_deps` definition with Python 3.11 skip logic

## Testing
- `pytest -q`
- `bash setup.sh` *(fails to download auto-sklearn but uses wheel for scikit-learn)*

------
https://chatgpt.com/codex/tasks/task_b_684be461b93883328c886dbf10fc7f0a