### PR TITLE
Fix env-as setup call order

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -139,7 +139,14 @@ install_env_tpa_deps() {
     pip install --upgrade pip
 
     # Install all Python dependencies from requirements.txt using wheels only
-    pip install --only-binary=:all: -r requirements.txt
+    if [[ "$PYTHON_CMD" == *"3.11"* ]]; then
+        # Auto-Sklearn is not available for Python 3.11; skip it for env-tpa
+        grep -v '^auto-sklearn' requirements.txt > /tmp/req_no_as.txt
+        pip install --only-binary=:all: -r /tmp/req_no_as.txt
+        rm /tmp/req_no_as.txt
+    else
+        pip install --only-binary=:all: -r requirements.txt
+    fi
 
     deactivate
     log_success "env-tpa dependencies installed successfully"
@@ -159,8 +166,9 @@ install_env_as_deps() {
     # Upgrade pip first
     pip install --upgrade pip
 
-    if [ "$PYTHON_MINOR" -ge 11 ]; then
-        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python $PYTHON_MINOR; installing base stack only"
+    # Auto-Sklearn is unavailable for Python 3.11, so only install the base stack
+    if [[ "$PYTHON_CMD" == *"3.11"* ]]; then
+        log_warning "Auto-Sklearn 0.15.0 is incompatible with Python 3.11; skipping installation"
         pip install --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
     else
         pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
@@ -379,10 +387,10 @@ main() {
     # setup_pyenv  # Commented out to use system Python directly
     create_directories
     create_environments
-    install_env_tpa_deps
     if [ "$ENABLE_AS" = true ]; then
         install_env_as_deps
     fi
+    install_env_tpa_deps
     test_environments
     post_setup_check
     create_activation_scripts


### PR DESCRIPTION
## Summary
- simplify install_env_as_deps logic and skip Auto-Sklearn when Python 3.11 is used
- skip Auto-Sklearn in env-tpa on Python 3.11
- run env-as install before env-tpa install so dependencies install once

## Testing
- `pytest -q`
- `bash setup.sh --with-as` *(fails: Could not find a binary distribution for python-logstash-async)*

------
https://chatgpt.com/codex/tasks/task_b_684be44cc84c833289d725c7ea2a875a