### PR TITLE
Clarify setup behavior on Python 3.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ./setup.sh [--with-as]
 ```
 
-This automatically creates the `env-tpa` Python environment, installs all dependencies (including `pandas`), and sets up the project structure. Use `--with-as` if you also want the optional Auto-Sklearn environment. After running it, activate the environment before using the orchestrator:
+This automatically creates the `env-tpa` Python environment, installs all dependencies (including `pandas`), and sets up the project structure. Use `--with-as` if you also want the optional Auto-Sklearn environment. On Python **3.11 or higher**, `setup.sh` skips Auto-Sklearn automatically and prepares only the TPOT/AutoGluon environment. After running it, activate the environment before using the orchestrator:
 
 ```bash
 ./activate-tpa.sh


### PR DESCRIPTION
## Summary
- document that setup.sh skips Auto-sklearn on Python 3.11+

## Testing
- `pytest -q`
- `python orchestrator.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684be47ba0608332845568668fabae6a