### PR TITLE
Add CPU resource controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ deactivate
 # Run the orchestrator (AutoGluon, Auto-Sklearn, and TPOT all run)
 python orchestrator.py --all --time 3600 \
   --data DataSets/3/predictors_Hold\ 1\ Full_20250527_151252.csv \
-  --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv
+  --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv \
+  --cpus 4
+
+# Use `--cpus` to limit how many threads each AutoML engine and the underlying
+# BLAS libraries may use. This is especially important when running inside a
+# Docker container with restricted CPU quotas.
 
 # The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
 # together. The `--all` flag is optional but included here for clarity.

--- a/engines/auto_sklearn_wrapper.py
+++ b/engines/auto_sklearn_wrapper.py
@@ -73,12 +73,13 @@ _AUTOSKLEARN_PREPROCESSOR_MAP = {
 class AutoSklearnEngine(BaseEngine):
     """Auto-Sklearn adapter conforming to the orchestrator's API."""
 
-    def __init__(self, seed: int, timeout_sec: int, run_dir: Path, metric: str = DEFAULT_METRIC):
+    def __init__(self, seed: int, timeout_sec: int, run_dir: Path, metric: str = DEFAULT_METRIC, n_cpus: int = 1):
         self.seed = seed
         self.timeout_sec = timeout_sec
         self.run_dir = run_dir
+        self.n_cpus = n_cpus
         self._automl: Any = None
-        self._metric: str = metric # Store the metric for best_pipeline_info
+        self._metric: str = metric  # Store the metric for best_pipeline_info
 
     @property
     def name(self) -> str:
@@ -152,7 +153,7 @@ class AutoSklearnEngine(BaseEngine):
                 resampling_strategy="holdout",
                 resampling_strategy_arguments={"train_size": 0.75},
                 metric=translated_metric,
-                n_jobs=1,  # prevent nested parallelism
+                n_jobs=self.n_cpus,  # prevent nested parallelism
                 seed=self.seed,
                 tmp_folder=self.run_dir / "autosklearn_tmp",
                 output_folder=self.run_dir / "autosklearn_out",
@@ -167,7 +168,7 @@ class AutoSklearnEngine(BaseEngine):
             logger.warning("[%s] library missing – fallback LinearRegression: %s", self.__class__.__name__, e)
             from sklearn.linear_model import LinearRegression
 
-            linreg = LinearRegression(n_jobs=1)
+            linreg = LinearRegression(n_jobs=self.n_cpus)
             linreg.fit(X, y)
             self._automl = linreg
 

--- a/engines/autogluon_wrapper.py
+++ b/engines/autogluon_wrapper.py
@@ -88,13 +88,14 @@ class AutoGluonEngine(BaseEngine):
         "LightGBM": "GBM",
     }
 
-    def __init__(self, seed: int, timeout_sec: int, run_dir: Path, metric: str = "r2"):
+    def __init__(self, seed: int, timeout_sec: int, run_dir: Path, metric: str = "r2", n_cpus: int = 1):
         self.seed = seed
         self.timeout_sec = timeout_sec
         self.run_dir = run_dir
+        self.n_cpus = n_cpus
         self._predictor: Any = None
         self._ag_output_path = self.run_dir / "autogluon_output"
-        self._metric: str = metric # Store the metric for best_pipeline_info
+        self._metric: str = metric  # Store the metric for best_pipeline_info
 
     @property
     def name(self) -> str:
@@ -174,6 +175,7 @@ class AutoGluonEngine(BaseEngine):
                 train_data=train_data,
                 presets="medium_quality_faster_train",  # Specific preset as required
                 time_limit=self.timeout_sec,
+                num_cpus=self.n_cpus,
                 # Only include models explicitly requested by the orchestrator from our allowed list
                 included_model_types=list(set(ag_included_models)) if ag_included_models else None,
             )
@@ -187,7 +189,7 @@ class AutoGluonEngine(BaseEngine):
             logger.warning("[%s] library missing – fallback LinearRegression: %s", self.__class__.__name__, e)
             from sklearn.linear_model import LinearRegression
 
-            linreg = LinearRegression(n_jobs=1)
+            linreg = LinearRegression(n_jobs=self.n_cpus)
             linreg.fit(X, y)
             self._predictor = linreg
 


### PR DESCRIPTION
## Summary
- add `--cpus` CLI flag to limit threads
- set thread-related env vars in orchestrator
- pass CPU count to engine wrappers
- update engine wrappers to respect requested threads
- document CPU limit in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c8fe3c0648330a5902ebbd081c54c