### PR TITLE
Switch environment to Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ The setup script supports Python 3.13 but with limitations:
 - **TPOT**: Works with Python 3.13 with compatibility warnings
 - **XGBoost/LightGBM**: Generally compatible with Python 3.13
 
-For best compatibility, install Python 3.11 using `pyenv`:
+For best compatibility, install Python 3.10 using `pyenv`:
 ```bash
-pyenv install 3.11.9
+pyenv install 3.10.13
 ```
 
 ### Manual Installation (if setup.sh fails)
 
 ```bash
-# Install Python 3.11 using pyenv if not already present
-pyenv install 3.11.9
+# Install Python 3.10 using pyenv if not already present
+pyenv install 3.10.13
 
 # Create the pyenv virtual environment
-pyenv virtualenv 3.11.9 automl-harness
+pyenv virtualenv 3.10.13 automl-harness
 
 # Activate the environment
 pyenv activate automl-harness
@@ -120,7 +120,7 @@ All runs generate artifacts in `05_outputs/<dataset_name>/`:
 ## System Requirements
 
 - Linux (recommended) or macOS
-- Python 3.11+ (recommended) or Python 3.13 (with limitations)
+- Python 3.10+ (recommended) or Python 3.13 (with limitations)
 - 8GB+ RAM for larger datasets
 
 - Build tools (`build-essential` on Ubuntu, `base-devel` on Arch) 
@@ -149,7 +149,7 @@ This project no longer provides direct Docker support in the `pyenv-only` branch
   install the required packages.
 
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
-  on Python 3.13. Use Python 3.11 for full functionality.
+  on Python 3.13. Use Python 3.10 for full functionality.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Add a `--tree` flag to `orchestrator.py` to optionally print artifact directories in tree form.
 - Create tests verifying tree-formatted output appears when the flag is used.
+- Migrate the pyenv setup to Python 3.10 (or 3.9) and reinstall `auto-sklearn` for compatibility with older `scikit-learn`.
 
 ## Status
 

--- a/info.md
+++ b/info.md
@@ -24,12 +24,12 @@ Each engine is a different approach to automated machine learning:
 - **🧬 TPOT** (`engines/tpot_wrapper.py`) 
   - Uses genetic programming (evolutionary algorithms)
   - Literally evolves ML pipelines like biological evolution
-  - Works with Python 3.11+
+  - Works with Python 3.10+
 
 - **⚡ AutoGluon** (`engines/autogluon_wrapper.py`)
   - Uses ensemble methods + neural architecture search
   - Super fast, often wins competitions
-  - Works with Python 3.11+
+  - Works with Python 3.10+
 
 ### **3. 🧩 Component Library (`components/`)**
 This is where the **building blocks** live that the AutoML engines can choose from:
@@ -44,7 +44,7 @@ This is where the **building blocks** live that the AutoML engines can choose fr
 The **entire reason for the complexity** is Python version incompatibility:
 
 - **`env-as/`** - Auto-Sklearn environment (Python ≤3.10)
-- **`env-tpa/`** - TPOT + AutoGluon environment (Python 3.11+)
+- **`env-tpa/`** - TPOT + AutoGluon environment (Python 3.10+)
 - **`setup.sh`** - Creates both environments with correct dependencies
 - **`activate-*.sh`** - Switches between environments
 
@@ -65,7 +65,7 @@ The **entire reason for the complexity** is Python version incompatibility:
 
 ### **The Python Version Problem:**
 - **Auto-Sklearn:** Only works on Python ≤3.10
-- **TPOT + AutoGluon:** Work best on Python 3.11+
+- **TPOT + AutoGluon:** Work best on Python 3.10+
 - **Solution:** Two separate environments managed by `setup.sh`
 
 ### **The Meta-AutoML Concept:**

--- a/scripts/run_tpot_ag.py
+++ b/scripts/run_tpot_ag.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""TPOT + AutoGluon Runner (Python 3.11 – env-tpa)
+"""TPOT + AutoGluon Runner (Python 3.10 – env-tpa)
 
 This script is meant to be executed from the *env-tpa* pyenv virtual
 environment. It expects that `tpot==1.0.0` and `autogluon.tabular`

--- a/setup.sh
+++ b/setup.sh
@@ -39,14 +39,17 @@ check_system() {
         log_warning "This script is optimized for Linux. Continuing anyway..."
     fi
     
-    # Check for available Python versions (strictly enforce 3.11)
-    if command -v python3.11 &> /dev/null; then
-        PYTHON_CMD="python3.11"
-        log_success "Found Python 3.11 (required)"
+    # Check for available Python versions (prefer 3.10, fallback to 3.9)
+    if command -v python3.10 &> /dev/null; then
+        PYTHON_CMD="python3.10"
+        log_success "Found Python 3.10 (required)"
+    elif command -v python3.9 &> /dev/null; then
+        PYTHON_CMD="python3.9"
+        log_success "Found Python 3.9 (required)"
     else
-        log_error "Python 3.11 is required but not found. Please install Python 3.11 before running this setup script."
-        log_info "For Ubuntu/Debian: sudo apt install python3.11 python3.11-venv python3.11-dev"
-        log_info "For Arch: sudo pacman -S python311"
+        log_error "Python 3.10 or 3.9 is required but neither was found. Please install Python 3.10 or 3.9 before running this setup script."
+        log_info "For Ubuntu/Debian: sudo apt install python3.10 python3.10-venv python3.10-dev"
+        log_info "For Arch: sudo pacman -S python310"
         exit 1
     fi
     
@@ -65,9 +68,9 @@ install_system_deps() {
     if command -v apt &> /dev/null; then
         log_info "Detected apt package manager"
         # We won't run sudo commands automatically, just inform user
-        if ! dpkg -l | grep -q python3.11-dev; then
-            log_warning "python3.11-dev not found. You may need to run:"
-            log_warning "sudo apt update && sudo apt install -y python3.11-dev build-essential"
+        if ! dpkg -l | grep -q python3.10-dev; then
+            log_warning "python3.10-dev not found. You may need to run:"
+            log_warning "sudo apt update && sudo apt install -y python3.10-dev build-essential"
         fi
     elif command -v pacman &> /dev/null; then
         log_info "Detected pacman package manager"
@@ -127,10 +130,10 @@ create_directories() {
 setup_pyenv_env() {
     log_info "Creating and setting up pyenv environment 'automl-harness'..."
     
-    # Ensure Python 3.11 is available via pyenv
-    if ! pyenv versions | grep -q "3.11"; then
-        log_info "Installing Python 3.11 with pyenv..."
-        pyenv install 3.11.9 || pyenv install 3.11
+    # Ensure Python 3.10 is available via pyenv
+    if ! pyenv versions | grep -q "3.10"; then
+        log_info "Installing Python 3.10 with pyenv..."
+        pyenv install 3.10.13 || pyenv install 3.10
     fi
     
     # Create or recreate the pyenv virtual environment
@@ -139,7 +142,7 @@ setup_pyenv_env() {
         pyenv virtualenv-delete -f automl-harness
     fi
     log_info "Creating pyenv virtual environment 'automl-harness'..."
-    pyenv virtualenv 3.11.9 automl-harness || pyenv virtualenv 3.11 automl-harness
+    pyenv virtualenv 3.10.13 automl-harness || pyenv virtualenv 3.10 automl-harness
     log_success "Created pyenv virtual environment 'automl-harness'"
     
     # Activate the environment and install dependencies


### PR DESCRIPTION
## Summary
- switch project environment to Python 3.10
- update setup script for Python 3.10
- adjust docs and CI workflow
- document new environment task in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cb29761fc8330bb8d07634cc51c28