### PR TITLE
Fix scikit-learn conflict for Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ pip install -r requirements.txt
 ```
 This step ensures modules like `pandas` are available before running `orchestrator.py`.
 
+`requirements.txt` now uses Python version markers to install compatible versions of `scikit-learn` and Auto-Sklearn. Python 3.10 installs `scikit-learn==0.24.2` alongside Auto-Sklearn, while Python 3.11+ installs `scikit-learn==1.4.2` for TPOT and AutoGluon.
+
 > **Note**
 > 
 > The AutoGluon engine depends on the `autogluon.tabular` package. If this library is missing, `autogluon_wrapper.py` falls back to a simple `LinearRegression`, which severely limits model quality. Run `./setup.sh` or the `pip install` command above to install the full AutoGluon dependencies and avoid the fallback.
@@ -80,13 +82,13 @@ python3.11 -m venv env-as
 # Install Auto-Sklearn environment (Python <=3.10 only)
 source env-as/bin/activate
 pip install --upgrade pip
-pip install auto-sklearn==0.15.0 numpy==1.24.3 scikit-learn==1.4.2 pandas matplotlib seaborn rich joblib
+pip install auto-sklearn==0.15.0 numpy==1.24.3 scikit-learn==0.24.2 pandas matplotlib seaborn rich joblib
 deactivate
 
 # Install TPOT + AutoGluon environment
 source env-tpa/bin/activate
 pip install --upgrade pip
-pip install setuptools tpot autogluon.tabular numpy scikit-learn pandas matplotlib seaborn rich joblib xgboost lightgbm
+pip install setuptools tpot autogluon.tabular numpy scikit-learn==1.4.2 pandas matplotlib seaborn rich joblib xgboost lightgbm
 deactivate
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
 - Smoke test for `orchestrator.py` passed successfully. All engines (AutoGluon, Auto-Sklearn, TPOT) executed, data loaded, split, and artifacts saved.
+- Resolved scikit-learn version conflict by using Python markers in `requirements.txt` and installing `scikit-learn==0.24.2` for the Auto-Sklearn environment.
 
 ## Remaining Action Items
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,10 @@ numpy==1.26.4
 rich==13.7.0
 pandas==2.2.1
 joblib==1.3.2
-scikit-learn==1.4.2
-auto-sklearn==0.15.0
-tpot==0.12.2
+scikit-learn==1.4.2; python_version>="3.11"
+scikit-learn==0.24.2; python_version<"3.11"
+auto-sklearn==0.15.0; python_version<"3.11"
+tpot==0.12.2; python_version>="3.11"
 scipy==1.11.4
 autogluon.tabular[all]==1.3.1
 psutil==5.9.8

--- a/setup.sh
+++ b/setup.sh
@@ -163,7 +163,7 @@ install_env_as_deps() {
         log_warning "Auto-Sklearn 0.15.0 is incompatible with Python $PYTHON_MINOR; installing base stack only"
         pip install --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
     else
-        pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
+        pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==0.24.2 matplotlib seaborn rich joblib
     fi
 
     deactivate


### PR DESCRIPTION
## Summary
- resolve scikit-learn conflict with python markers in requirements.txt
- install scikit-learn 0.24.2 for the Auto-Sklearn environment
- document version markers and update manual installation docs
- log completed fix in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cb64d349c83309e346e043539e888