### PR TITLE
Fix requirements and note autosklearn issue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,3 +19,4 @@
 
 The setup script now creates the `automl-harness` pyenv environment by default and installs all required packages. Activation is done via `pyenv activate automl-harness`.
 
+- Investigate auto-sklearn installation failure on Python 3.11 and document workaround (e.g., use Python 3.9 or compile scikit-learn 0.24).

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==4.0.2


### PR DESCRIPTION
## Summary
- adjust python-logstash-async version in requirements
- note autosklearn 3.11 issue in TODO

## Testing
- `pytest -q`
- `python orchestrator.py --all --time 60 --data DataSets/1/D1-Predictors.csv --target DataSets/1/D1-Targets.csv`

------
https://chatgpt.com/codex/tasks/task_b_684cb28f4ee883309b462bd3fb34054c