### PR TITLE
Add run_all script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ ensuring they persist between runs.
 
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.
+- **Quick test** – Run `./run_all.sh` to execute the orchestrator on a sample dataset. The script activates `env-tpa`, runs all engines for 60 seconds, then deactivates.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
 - Smoke test for `orchestrator.py` passed successfully. All engines (AutoGluon, Auto-Sklearn, TPOT) executed, data loaded, split, and artifacts saved.
+- Added `run_all.sh` script to run the orchestrator with all engines for 60-second test on sample data.
 
 ## Remaining Action Items
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run orchestrator on sample dataset using all engines
+
+# Exit if any command fails
+set -e
+
+# Activate TPOT + AutoGluon environment
+source ./activate-tpa.sh
+
+# Execute orchestrator with all engines for a short run
+python orchestrator.py --all --time 60 \
+  --data DataSets/1/D1-Predictors.csv \
+  --target DataSets/1/D1-Targets.csv
+
+# Deactivate environment
+deactivate
+


### PR DESCRIPTION
## Summary
- create `run_all.sh` to quickly run all AutoML engines
- document script usage in README troubleshooting section
- note the script in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cb9cdb9fc833096eddb0c809acdd9