### PR TITLE
Fix TODO after adding smoke test script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 ## Completed Tasks
-- Added run_all.sh for 60-second smoke test.
+- Added `run_all.sh` script to run the orchestrator with all three engines for a 60-second smoke test.
 
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
@@ -17,7 +17,6 @@
 - Add a `--tree` flag to `orchestrator.py` to optionally print artifact directories in tree form.
 - Create tests verifying tree-formatted output appears when the flag is used.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
-- Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- clarify that `run_all.sh` runs all engines in TODO
- remove obsolete TODO entry for missing `run_all.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cbbd6f7b0833083349f6508eb6662