### PR TITLE
Skip optional Auto-Sklearn activation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,12 +238,14 @@ ensuring they persist between runs.
   Optionally switch to the Auto-Sklearn environment with `pyenv activate automl-py310`.
   Deactivate the current environment at any time using `pyenv deactivate`.
 
-- **Setup problems** – If `./setup.sh` fails, follow the instructions in the
-  *Manual Installation* section to create `env-as` and `env-tpa` manually and
-  install the required packages.
+  - **Setup problems** – If `./setup.sh` fails, follow the instructions in the
+    *Manual Installation* section to create `env-as` and `env-tpa` manually and
+    install the required packages.
+  - **No Auto-Sklearn tests** – `setup.sh` skips the Auto-Sklearn activation test
+    when the `env-as` environment is not created.
 
-- **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
-  on Python 3.13. Use Python 3.11 for full functionality.
+  - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
+    on Python 3.13. Use Python 3.11 for full functionality.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,11 @@
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
 - Smoke test for `orchestrator.py` passed successfully. All engines (AutoGluon, Auto-Sklearn, TPOT) executed, data loaded, split, and artifacts saved.
 - Resolved scikit-learn version conflict by specifying `scikit-learn>=1.4.2,<1.6` so Auto-Sklearn and TPOT install together.
+- Updated `setup.sh` to skip the Auto-Sklearn activation test when the `env-as` environment is not enabled.
 
 ## Remaining Action Items
 
 - Update environment setup to ensure required Python packages (e.g., pandas) are installed before running the orchestrator.
-- Modify `setup.sh` to either create `env-as` or skip the activation test if it is not needed.
 - Update `setup.sh` to create `automl-py310` and `automl-py311` pyenv environments automatically.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Add a `--tree` flag to `orchestrator.py` to optionally print artifact directories in tree form.

--- a/setup.sh
+++ b/setup.sh
@@ -190,10 +190,11 @@ create_directories() {
 test_environments() {
     log_info "Testing environment installations..."
     
-    # Test env-as only if it exists
-    if [ -d "env-as" ]; then
-        log_info "Testing env-as environment..."
-        source env-as/bin/activate
+    # Test env-as only when enabled
+    if [ "$ENABLE_AS" = true ]; then
+        if [ -d "env-as" ]; then
+            log_info "Testing env-as environment..."
+            source env-as/bin/activate
 
         if [[ "$PYTHON_CMD" == "python3.13" ]]; then
             python -c "
@@ -218,9 +219,13 @@ print(f'  - NumPy version: {np.__version__}')
 print(f'  - Pandas version: {pd.__version__}')
 "
         fi
-        deactivate
+            deactivate
+        else
+            log_error "env-as environment requested but not found."
+            return 1
+        fi
     else
-        log_warning "env-as environment not found. Skipping Auto-Sklearn test."
+        log_info "env-as not enabled; skipping Auto-Sklearn test."
     fi
     
     # Test env-tpa


### PR DESCRIPTION
## Summary
- make Auto-Sklearn environment test conditional on ENABLE_AS
- document that Auto-Sklearn activation test is skipped when env-as isn't created
- note update in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cbbc5ca3c8330b577107c413e87be