### PR TITLE
Update docs on engine usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Run the helper script to verify your setup. It activates the default environment
 ./run_all.sh
 ```
 All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously. The `--all` flag ensures every run evaluates each engine before selecting a champion.
+Running the orchestrator with only one engine (e.g., AutoGluon) is not currently supported because `AGENTS.md` mandates that all three wrappers run together.
 
 ## Project Structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - Create tests verifying tree-formatted output appears when the flag is used.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Investigate allowing single-engine orchestrations (e.g., AutoGluon only). This cannot proceed unless `AGENTS.md` is updated to permit running engines individually.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- add note that the orchestrator must run all three AutoML engines
- document that single-engine runs require AGENTS.md update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cbe47f3988330a4100da4f83afd3d