### PR TITLE
Add offline setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ ensuring they persist between runs.
 
 - **Setup problems** – If `./setup.sh` fails, follow the instructions in the
   *Manual Installation* section to create `env-as` and `env-tpa` manually and
-  install the required packages.
+  install the required packages. If network access is restricted,
+  bundle the required wheels or configure a local PyPI mirror so
+  setup and `make test` can run offline.
 
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - Create tests verifying tree-formatted output appears when the flag is used.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- add note about bundling wheels or using a local PyPI mirror for offline setup
- track this action item in TODO

## Testing
- `make test` *(fails: Could not find auto-sklearn)*

------
https://chatgpt.com/codex/tasks/task_b_684cbf4d4e608330a5d362f230be579e