### PR TITLE
Update TODO for package install reliability

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - Create tests verifying tree-formatted output appears when the flag is used.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- add a remaining action item to revise setup or CI so that packages like `rich` install reliably without manual steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc023ce608330a8995752de4bcb59