### PR TITLE
Enforce multi-engine runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pyenv deactivate
    You can call scripts without activating an environment by using `pyenv exec`:
 
    ```bash
-   pyenv exec python3.11 orchestrator.py --all
+   pyenv exec python3.11 orchestrator.py
    ```
 
 4. **Troubleshooting**
@@ -137,7 +137,7 @@ pyenv deactivate
 pyenv activate automl-py311
 
 # Run the orchestrator (AutoGluon, Auto-Sklearn, and TPOT all run)
-python orchestrator.py --all --time 3600 \
+python orchestrator.py --time 3600 \
   --data DataSets/3/predictors_Hold\ 1\ Full_20250527_151252.csv \
   --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv \
   --cpus 4
@@ -147,7 +147,7 @@ python orchestrator.py --all --time 3600 \
 # Docker container with restricted CPU quotas.
 
 # The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
-# together. The `--all` flag is optional but included here for clarity.
+# together. No additional flags are required.
 pyenv deactivate
 ```
 
@@ -158,7 +158,7 @@ Run the helper script to verify your setup. It activates the default environment
 ```bash
 ./run_all.sh
 ```
-All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously. The `--all` flag ensures every run evaluates each engine before selecting a champion.
+All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously. No flags are needed to include all engines.
 
 ## Project Structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Completed Tasks
 - Added run_all.sh for 60-second smoke test.
+- Orchestrator CLI simplified: engine selection flags removed; all runs now execute AutoGluon, Auto-Sklearn, and TPOT together.
 
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
@@ -17,7 +18,6 @@
 - Add a `--tree` flag to `orchestrator.py` to optionally print artifact directories in tree form.
 - Create tests verifying tree-formatted output appears when the flag is used.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
-- Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
 
 ## Status
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -735,26 +735,6 @@ def _cli() -> None:
         help=f"Evaluation metric (e.g., r2, neg_mean_squared_error). Default: {DEFAULT_METRIC}",
     )
     parser.add_argument(
-        "--all",
-        action="store_true",
-        help="Run all available AutoML engines",
-    )
-    parser.add_argument(
-        "--autogluon",
-        action="store_true",
-        help="Run only the AutoGluon engine",
-    )
-    parser.add_argument(
-        "--autosklearn",
-        action="store_true",
-        help="Run only the Auto-Sklearn engine",
-    )
-    parser.add_argument(
-        "--tpot",
-        action="store_true",
-        help="Run only the TPOT engine",
-    )
-    parser.add_argument(
         "--no-ensemble",
         action="store_true",
         help="Disable ensemble creation even if multiple engines are run",
@@ -774,22 +754,8 @@ def _cli() -> None:
         logger.error(str(exc))
         sys.exit(1)
 
-    if not (args.all or args.autogluon or args.autosklearn or args.tpot):
-        parser.error("At least one engine must be selected: --all, --autogluon, --autosklearn, or --tpot")
-
-    selected_engines = []
-    if args.all:
-        selected_engines = ["autogluon", "autosklearn", "tpot"]
-    else:
-        if args.autogluon:
-            selected_engines.append("autogluon")
-        if args.autosklearn:
-            selected_engines.append("autosklearn")
-        if args.tpot:
-            selected_engines.append("tpot")
-
-    if not selected_engines:
-        parser.error("No engines selected. Please use --all or specify at least one engine with --autogluon, --autosklearn, or --tpot.")
+    # Orchestration always runs all supported engines together
+    selected_engines = ["autogluon", "autosklearn", "tpot"]
 
     # Define unique run directory for artifacts
     timestamp_str = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/run_all.sh
+++ b/run_all.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/activate-tpa.sh"
 
 # Execute orchestrator with sample dataset
-python "$SCRIPT_DIR/orchestrator.py" --all --time 60 \
+python "$SCRIPT_DIR/orchestrator.py" --time 60 \
   --data "$SCRIPT_DIR/DataSets/1/D1-Predictors.csv" \
   --target "$SCRIPT_DIR/DataSets/1/D1-Targets.csv" "$@"
 


### PR DESCRIPTION
## Summary
- enforce using all AutoML engines simultaneously by default
- update docs and helper script to match new interface
- document the CLI simplification in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cbcce735c83309ef0635e797dc4a1