### PR TITLE
Update docs and CLI to enforce triple-engine runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHONY += setup test clean
+.PHONY: setup test clean
 
 setup:
 	@echo "Setting up the AutoML Harness environment..."

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ python orchestrator.py --all --time 3600 \
 # BLAS libraries may use. This is especially important when running inside a
 # Docker container with restricted CPU quotas.
 
-# The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
-# together. The `--all` flag is optional but included here for clarity.
+# The orchestrator always runs Auto-Sklearn, TPOT and AutoGluon
+# together. The `--all` flag is implied.
 pyenv deactivate
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,10 @@
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
-- Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Document and enforce that all orchestrations run Auto-Sklearn, TPOT, and AutoGluon together.
+- Update README to clarify that the `--all` flag is implied.
+- Update Makefile to declare phony targets correctly.
+- Fix escape sequence warning in `run_tpot_ag.py` docstring.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -757,22 +757,7 @@ def _cli() -> None:
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Run all available AutoML engines",
-    )
-    parser.add_argument(
-        "--autogluon",
-        action="store_true",
-        help="Run only the AutoGluon engine",
-    )
-    parser.add_argument(
-        "--autosklearn",
-        action="store_true",
-        help="Run only the Auto-Sklearn engine",
-    )
-    parser.add_argument(
-        "--tpot",
-        action="store_true",
-        help="Run only the TPOT engine",
+        help="Run all available AutoML engines (default)",
     )
     parser.add_argument(
         "--no-ensemble",
@@ -799,22 +784,7 @@ def _cli() -> None:
         logger.error(str(exc))
         sys.exit(1)
 
-    if not (args.all or args.autogluon or args.autosklearn or args.tpot):
-        parser.error("At least one engine must be selected: --all, --autogluon, --autosklearn, or --tpot")
-
-    selected_engines = []
-    if args.all:
-        selected_engines = ["autogluon", "autosklearn", "tpot"]
-    else:
-        if args.autogluon:
-            selected_engines.append("autogluon")
-        if args.autosklearn:
-            selected_engines.append("autosklearn")
-        if args.tpot:
-            selected_engines.append("tpot")
-
-    if not selected_engines:
-        parser.error("No engines selected. Please use --all or specify at least one engine with --autogluon, --autosklearn, or --tpot.")
+    selected_engines = ["autogluon", "autosklearn", "tpot"]
 
     # Define unique run directory for artifacts
     timestamp_str = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/scripts/run_tpot_ag.py
+++ b/scripts/run_tpot_ag.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""TPOT + AutoGluon Runner (Python 3.11 – automl-py311)
+r"""TPOT + AutoGluon Runner (Python 3.11 – automl-py311)
 
 This script is meant to be executed from the *automl-py311* pyenv virtual
 environment. It expects that `tpot==1.0.0` and `autogluon.tabular`


### PR DESCRIPTION
## Summary
- clarify `--all` flag always implied
- remove single-engine CLI options and set default engine list
- declare phony targets in Makefile
- clean up docstring escapes
- expand TODO for next steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc3a96c648330b8ee053cdd68f2ac