### PR TITLE
Switch run_all to pyenv exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ pyenv deactivate
 
 
 ### Quick Smoke Test
-Run the helper script to verify your setup. It activates the default environment and runs all three engines for 60 seconds on the sample dataset:
+Run the helper script to verify your setup. It uses `pyenv exec` with the `automl-py311` environment and runs all three engines for 60 seconds on the sample dataset:
 
 ```bash
 ./run_all.sh

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Completed Tasks
 - Added run_all.sh for 60-second smoke test.
+- Updated run_all.sh to use `pyenv exec` with the `automl-py311` environment.
 
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
@@ -15,10 +16,11 @@
 - Update environment setup to ensure required Python packages (e.g., pandas) are installed before running the orchestrator.
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
-- Verify `run_all.sh` smoke test passes after updating dependencies.
-- Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Verify `run_all.sh` (now using `pyenv exec`) passes the smoke test after updating dependencies.
+- Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test. [COMPLETED]
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
+- Ensure the `pyenv-virtualenv` plugin is installed so `automl-py311` exists for `pyenv exec`.
 
 ## Status
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -5,13 +5,9 @@ set -euo pipefail
 # Determine script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Activate default environment
-pyenv activate automl-py311
-
-# Execute orchestrator with sample dataset
-python "$SCRIPT_DIR/orchestrator.py" --all --time 60 \
+# Execute orchestrator with sample dataset using automl-py311
+PYENV_VERSION=automl-py311 pyenv exec python "$SCRIPT_DIR/orchestrator.py" --all --time 60 \
   --data "$SCRIPT_DIR/DataSets/1/D1-Predictors.csv" \
   --target "$SCRIPT_DIR/DataSets/1/D1-Targets.csv" "$@"
 
-pyenv deactivate
 


### PR DESCRIPTION
## Summary
- update `run_all.sh` to run orchestrator using `pyenv exec`
- document the new approach in the README
- update agent tasks with completed work and follow-up item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc4914a80833088c8202f52ef93ed