### PR TITLE
Fix deactivate in setup script

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - Added `--tree` flag to `orchestrator.py` to display artifact directory trees and implemented tests verifying the output.
 - Reviewed and processed 9 pull requests: accepted 4 valuable PRs (run_all.sh, offline setup docs, tree flag, pyenv migration) and declined 5 problematic PRs (regressions, breaking changes, duplicates).
 - Added offline setup documentation for restricted network environments.
+- Replaced leftover `deactivate` command in `setup.sh` with `pyenv deactivate`.
 
 ## Remaining Action Items
 
@@ -19,6 +20,7 @@
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
+- Fix `make test` target in the Makefile to resolve the "missing separator" error.
 - Review and process 4 new open pull requests (#88, #89, #90, #91).
 
 ## Status

--- a/setup.sh
+++ b/setup.sh
@@ -274,7 +274,7 @@ print(f'  - NumPy version: {np.__version__}')
 print(f'  - Pandas version: {pd.__version__}')
 "
     fi
-    deactivate
+    pyenv deactivate
     
     log_success "All environments tested successfully"
 }


### PR DESCRIPTION
## Summary
- call `pyenv deactivate` at the end of setup tests
- document the change in TODO
- note that Makefile test target needs a fix

## Testing
- `make test` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_b_684cc5054e4483308be769dadae39b03