### PR TITLE
Fix pyenv initialization for run_all.sh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Add a missing `run_all.sh` script to launch the orchestrator with all three engines for a quick smoke test.
+- Fix `run_all.sh` so it initializes pyenv when run in a non-interactive shell.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -2,6 +2,18 @@
 # Run orchestrator with all engines for a 60-second smoke test
 set -euo pipefail
 
+# Load pyenv so that `pyenv activate` works even when the script is executed
+# non-interactively.
+export PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
+export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+if command -v pyenv >/dev/null; then
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+else
+    echo "pyenv not found; aborting" >&2
+    exit 1
+fi
+
 # Determine script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## Summary
- ensure `run_all.sh` loads pyenv before activating the environment
- track new TODO to fix pyenv initialization during smoke test

## Testing
- `pytest -q`
- `./run_all.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684cc41b556c8330a7dac343e1a63d15