### PR TITLE
Document pyenv-virtualenv requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ tpot_*_pipeline.py
 .autogluon/
 autogluon_models/
 05_outputs/**/autogluon_output/
+automl-py311/
 
 # MLflow
 mlruns/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This automatically creates the `automl-py311` and optional `automl-py310`
 environments using **pyenv**. After running it, activate the environment before
 using the orchestrator:
 
+> **Important**: `setup.sh` and `run_all.sh` rely on the `pyenv-virtualenv`
+> plugin. Install it so the `pyenv virtualenv` and `pyenv activate` commands
+> are available. If the plugin is missing, create and activate a standard
+> `venv` manually instead.
+
 ```bash
 pyenv activate automl-py311
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,8 @@
 ## Remaining Action Items
 
 - Update environment setup to ensure required Python packages (e.g., pandas) are installed before running the orchestrator.
+- Document the need for the **pyenv-virtualenv** plugin so `setup.sh` and
+  `run_all.sh` can use `pyenv activate`.
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.


### PR DESCRIPTION
## Summary
- mention the pyenv-virtualenv plugin in the README
- note this requirement in TODO
- ignore the `automl-py311/` venv directory

## Testing
- `pip install numpy==1.26.4`

------
https://chatgpt.com/codex/tasks/task_b_684cc41b556c8330a7dac343e1a63d15