### PR TITLE
Default orchestrator to all engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pyenv deactivate
    You can call scripts without activating an environment by using `pyenv exec`:
 
    ```bash
-   pyenv exec python3.11 orchestrator.py --all
+   pyenv exec python3.11 orchestrator.py
    ```
 
 4. **Troubleshooting**
@@ -136,8 +136,8 @@ pyenv deactivate
 # Activate the appropriate environment
 pyenv activate automl-py311
 
-# Run the orchestrator (AutoGluon, Auto-Sklearn, and TPOT all run)
-python orchestrator.py --all --time 3600 \
+# Run the orchestrator (all engines run by default)
+python orchestrator.py --time 3600 \
   --data DataSets/3/predictors_Hold\ 1\ Full_20250527_151252.csv \
   --target DataSets/3/targets_Hold\ 1\ Full_20250527_151252.csv \
   --cpus 4 \
@@ -147,8 +147,8 @@ python orchestrator.py --all --time 3600 \
 # BLAS libraries may use. This is especially important when running inside a
 # Docker container with restricted CPU quotas.
 
-# The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
-# together. The `--all` flag is optional but included here for clarity.
+# The orchestrator always runs Auto-Sklearn, TPOT and AutoGluon together.
+# The `--all` flag is retained for clarity but has no effect.
 pyenv deactivate
 ```
 
@@ -159,7 +159,7 @@ Run the helper script to verify your setup. It activates the default environment
 ```bash
 ./run_all.sh
 ```
-All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously. The `--all` flag ensures every run evaluates each engine before selecting a champion.
+All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously by default. There are no engine-specific flags.
 
 ## Project Structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - Added `--tree` flag to `orchestrator.py` to display artifact directory trees and implemented tests verifying the output.
 - Reviewed and processed 9 pull requests: accepted 4 valuable PRs (run_all.sh, offline setup docs, tree flag, pyenv migration) and declined 5 problematic PRs (regressions, breaking changes, duplicates).
 - Added offline setup documentation for restricted network environments.
+- Removed single-engine flags so orchestrator always runs all three engines by default.
 
 ## Remaining Action Items
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -757,22 +757,7 @@ def _cli() -> None:
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Run all available AutoML engines",
-    )
-    parser.add_argument(
-        "--autogluon",
-        action="store_true",
-        help="Run only the AutoGluon engine",
-    )
-    parser.add_argument(
-        "--autosklearn",
-        action="store_true",
-        help="Run only the Auto-Sklearn engine",
-    )
-    parser.add_argument(
-        "--tpot",
-        action="store_true",
-        help="Run only the TPOT engine",
+        help="Run all available AutoML engines (default behavior)",
     )
     parser.add_argument(
         "--no-ensemble",
@@ -799,22 +784,8 @@ def _cli() -> None:
         logger.error(str(exc))
         sys.exit(1)
 
-    if not (args.all or args.autogluon or args.autosklearn or args.tpot):
-        parser.error("At least one engine must be selected: --all, --autogluon, --autosklearn, or --tpot")
-
-    selected_engines = []
-    if args.all:
-        selected_engines = ["autogluon", "autosklearn", "tpot"]
-    else:
-        if args.autogluon:
-            selected_engines.append("autogluon")
-        if args.autosklearn:
-            selected_engines.append("autosklearn")
-        if args.tpot:
-            selected_engines.append("tpot")
-
-    if not selected_engines:
-        parser.error("No engines selected. Please use --all or specify at least one engine with --autogluon, --autosklearn, or --tpot.")
+    # Always run all engines; --all is retained for backward compatibility
+    selected_engines = ["autogluon", "autosklearn", "tpot"]
 
     # Define unique run directory for artifacts
     timestamp_str = datetime.now().strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
## Summary
- remove `--autogluon`, `--autosklearn`, and `--tpot` flags
- default orchestrator to always run all engines
- clarify README usage to show default behavior
- note this change in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc5060b2c8330b6eb8c67762fbf46