### PR TITLE
Update TODO for run_all note

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Completed Tasks
 - Added run_all.sh for 60-second smoke test.
+- run_all.sh script is now available for quick orchestrator smoke tests.
 - Git LFS setup completed, including tracking of `.pkl`, `.json`, `DataSets/`, and `05_outputs/` directories. Git history has been cleaned to properly track large files.
 - `orchestrator.py` `AttributeError` for duration calculation fixed.
 - Smoke test for `orchestrator.py` passed successfully. All engines (AutoGluon, Auto-Sklearn, TPOT) executed, data loaded, split, and artifacts saved.


### PR DESCRIPTION
## Summary
- clarify that `run_all.sh` is available for quick smoke testing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cc504758c83308ec5fb4e08e4ad8a