### PR TITLE
Update logstash and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ pyenv deactivate
    pyenv deactivate
    ```
 
+   Python 3.11 users must upgrade to `python-logstash-async>=3.0.0`.
+
 3. **Running Scripts with Specific Versions**
 
    You can call scripts without activating an environment by using `pyenv exec`:

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - Added `--tree` flag to `orchestrator.py` to display artifact directory trees and implemented tests verifying the output.
 - Reviewed and processed 9 pull requests: accepted 4 valuable PRs (run_all.sh, offline setup docs, tree flag, pyenv migration) and declined 5 problematic PRs (regressions, breaking changes, duplicates).
 - Added offline setup documentation for restricted network environments.
+- Updated `python-logstash-async` to version 3.0.0 for Python 3.11 compatibility.
 - Completed systematic PR review and cleanup: processed all open PRs (13 total), closed duplicates and problematic PRs, maintained clean repository state.
 
 ## Remaining Action Items

--- a/requirements-py310.txt
+++ b/requirements-py310.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==3.0.0

--- a/requirements-py311.txt
+++ b/requirements-py311.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==3.0.0


### PR DESCRIPTION
## Summary
- pin python-logstash-async 3.0.0 for Python 3.11
- document logstash requirement
- note dependency update in TODO

## Testing
- `pytest -q`
- `./setup.sh --with-as` *(fails: pyenv: no such command `virtualenv`)*
- `./run_all.sh` *(fails: pyenv: no such command `activate`)*

------
https://chatgpt.com/codex/tasks/task_b_684cc5f051108330a1470fe46a5af014