### PR TITLE
Update TODO with Auto-Sklearn install note

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
+- **New:** Ensure Auto-Sklearn can install by creating a Python 3.10 environment (run `./setup.sh --with-as`), since it fails on Python 3.11.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- document that Auto-Sklearn requires a Python 3.10 environment

## Testing
- `pip install pandas==2.2.1`
- `pip install tpot==0.12.2`
- `pip install "scikit-learn>=1.4.2,<1.6"`
- `pip install auto-sklearn==0.15.0` *(fails)*

------
https://chatgpt.com/codex/tasks/task_b_684cc7e0b6e0833097abae20a2bf03fc