### PR TITLE
Add offline install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,28 @@ pyenv deactivate
 # Install TPOT + AutoGluon environment
 pyenv activate automl-py311
 pip install --upgrade pip
-pip install setuptools tpot autogluon.tabular numpy scikit-learn\>=1.4.2,<1.6 pandas matplotlib seaborn rich joblib xgboost lightgbm
-pyenv deactivate
+  pip install setuptools tpot autogluon.tabular numpy scikit-learn\>=1.4.2,<1.6 pandas matplotlib seaborn rich joblib xgboost lightgbm
+  pyenv deactivate
 ```
+
+### Offline Installation
+
+If your workstation does not have internet access, pre-download all required
+wheels on another machine:
+
+```bash
+pip download -r requirements.txt -d wheelhouse
+```
+
+Copy the resulting `wheelhouse/` directory to the offline environment and
+install packages locally:
+
+```bash
+pip install --no-index --find-links=wheelhouse -r requirements.txt
+```
+
+This method ensures `pandas`, AutoGluon, TPOT, and Auto-Sklearn install without
+contacting PyPI.
 
 ## Running the Orchestrator
 
@@ -149,6 +168,18 @@ python orchestrator.py --all --time 3600 \
 
 # The orchestrator automatically runs Auto-Sklearn, TPOT and AutoGluon
 # together. The `--all` flag is optional but included here for clarity.
+pyenv deactivate
+```
+
+### Example: Training on Dataset 2
+
+Use the built-in `DataSets/2/` files for a quick test run:
+
+```bash
+pyenv activate automl-py311
+python orchestrator.py --all \
+  --data DataSets/2/D2-Predictors.csv \
+  --target DataSets/2/D2-Targets.csv
 pyenv deactivate
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,11 +15,14 @@
 ## Remaining Action Items
 
 - Update environment setup to ensure required Python packages (e.g., pandas) are installed before running the orchestrator.
+- Investigate pip installation failures caused by restricted network access and provide offline installation guidance for core AutoML packages.
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
+- Document offline wheel installation steps in `README.md` using a local
+  `wheelhouse` directory.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- document offline installation via wheelhouse directory
- track offline wheel instructions as action item

## Testing
- `none`


------
https://chatgpt.com/codex/tasks/task_b_684cc7ef110483308334b3b0c579e13b