### PR TITLE
Fix Makefile and document setup issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHONY += setup test clean
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
 	@echo "Cleanup complete." 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 ./setup.sh [--with-as]
 ```
 
+You can also invoke the same process through `make`:
+
+```bash
+make setup
+```
+If this fails with `pyenv: no such command 'virtualenv'`, install the
+`pyenv-virtualenv` plugin so `setup.sh` can create environments automatically.
+
 This automatically creates the `automl-py311` and optional `automl-py310`
 environments using **pyenv**. After running it, activate the environment before
 using the orchestrator:
@@ -245,6 +253,9 @@ ensuring they persist between runs.
   manually and install the required packages. If network access is restricted,
   bundle the required wheels or configure a local PyPI mirror so
   setup and `make test` can run offline.
+- **pyenv missing 'virtualenv'** – `make setup` uses `pyenv virtualenv` to create
+  environments. Install the `pyenv-virtualenv` plugin if you encounter
+  `pyenv: no such command 'virtualenv'`.
 
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,7 @@
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 - Apply the `deactivate` to `pyenv deactivate` fix from rejected PR #96 to `setup.sh`.
+- Detect missing `pyenv-virtualenv` plugin during setup and provide instructions to install it when `pyenv virtualenv` is unavailable.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- fix Makefile indentation so make targets run
- document `make setup` usage and how to resolve missing `pyenv virtualenv`
- add troubleshooting note for missing `pyenv-virtualenv` plugin
- track follow-up task in TODO

## Testing
- `make setup` *(fails: pyenv: no such command `virtualenv`)*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_b_684cca00954c8330b2f41da39ac48a3d