### PR TITLE
Fix Makefile indentation, document pyenv-virtualenv need

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHONY += setup test clean
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
 	@echo "Cleanup complete." 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ ensuring they persist between runs.
   bundle the required wheels or configure a local PyPI mirror so
   setup and `make test` can run offline.
 
+- **`make setup` fails with `pyenv: no such command 'virtualenv'`** – Install
+  the `pyenv-virtualenv` plugin so `pyenv virtualenv` is available. Refer to the
+  [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) documentation for
+  installation steps.
+
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - Completed systematic PR review and cleanup: processed all open PRs (13 total), closed duplicates and problematic PRs, maintained clean repository state.
 - Fixed `run_all.sh` so it initializes pyenv when run in a non-interactive shell.
 - Completed systematic review of PRs #94-#97: merged PR #97 (pyenv initialization fix) and rejected PRs #94-#96 (all attempted to revert the pyenv improvements).
+- Fixed Makefile indentation so `make setup` and `make clean` run correctly.
 
 ## Remaining Action Items
 
@@ -23,6 +24,7 @@
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 - Apply the `deactivate` to `pyenv deactivate` fix from rejected PR #96 to `setup.sh`.
+- Install the `pyenv-virtualenv` plugin so `make setup` works without errors.
 
 ## Status
 


### PR DESCRIPTION
## Summary
- fix indentation in Makefile so make targets work
- document failure when pyenv-virtualenv is missing
- note the Makefile fix in TODO

## Testing
- `make setup` *(fails: pyenv: no such command `virtualenv`)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_b_684cca05950883308f88ad3e7d5ac441