### PR TITLE
Document run_all failure and plan fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Run the helper script to verify your setup. It activates the default environment
 ```bash
 ./run_all.sh
 ```
+If the script fails with missing modules or `pyenv` errors, run `./setup.sh` first to install dependencies and initialize the environments.
 All orchestrations run **AutoGluon**, **Auto-Sklearn**, and **TPOT** simultaneously. The `--all` flag ensures every run evaluates each engine before selecting a champion.
 
 ## Project Structure

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,7 @@
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
+- Install `pyenv-virtualenv` and ensure dependencies install correctly so `run_all.sh` passes.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 - Apply the `deactivate` to `pyenv deactivate` fix from rejected PR #96 to `setup.sh`.


### PR DESCRIPTION
## Summary
- document that run_all.sh may fail without setup.sh
- note that installing pyenv-virtualenv should help the smoke test pass

## Testing
- `./run_all.sh` *(fails: pyenv: no such command `virtualenv-init`)*

------
https://chatgpt.com/codex/tasks/task_b_684cca943cb88330bcc7146ed2ff184e