### PR TITLE
Fix CI dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements-py311.txt
           pip install pytest
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ ensuring they persist between runs.
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.
 
+### Continuous Integration
+
+The GitHub Actions workflow installs dependencies from `requirements-py311.txt`
+before running tests. This ensures packages like `rich` are available without
+manual intervention.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
 - Fixed `run_all.sh` so it initializes pyenv when run in a non-interactive shell.
 - Completed systematic review of PRs #94-#97: merged PR #97 (pyenv initialization fix) and rejected PRs #94-#96 (all attempted to revert the pyenv improvements).
 - Completed massive PR cleanup: systematically reviewed and closed PRs #98-#108 (11 PRs total) - all were based on outdated main branch and would have reverted recent improvements.
+- Updated CI to install dependencies from `requirements-py311.txt`, ensuring packages like `rich` are available automatically.
 
 ## Remaining Action Items
 
@@ -21,7 +22,6 @@
 - Modify `setup.sh` to skip automl-py310 creation gracefully when Python 3.10 is unavailable.
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
-- Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
 - Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 - Apply the `deactivate` to `pyenv deactivate` fix from rejected PR #96 to `setup.sh`.
 


### PR DESCRIPTION
## Summary
- install packages from requirements-py311.txt in CI
- note CI dependency install step in the README
- document CI update in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cca97815c833096fdac6e8cadc82d