### PR TITLE
Add offline wheel setup support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHONY += setup test clean
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
 	@echo "Cleanup complete." 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,23 @@ ensuring they persist between runs.
   bundle the required wheels or configure a local PyPI mirror so
   setup and `make test` can run offline.
 
+### Offline Setup
+
+If your environment restricts network access, first download the required
+packages while online:
+
+```bash
+./scripts/download_wheels.sh /path/to/wheels
+```
+
+Then set the `OFFLINE_WHEELS` environment variable to that directory before
+running `setup.sh` or `make test`:
+
+```bash
+export OFFLINE_WHEELS=/path/to/wheels
+make test
+```
+
 - **Python version incompatibilities** – AutoGluon and Auto-Sklearn are skipped
   on Python 3.13. Use Python 3.11 for full functionality.
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - Added `--tree` flag to `orchestrator.py` to display artifact directory trees and implemented tests verifying the output.
 - Reviewed and processed 9 pull requests: accepted 4 valuable PRs (run_all.sh, offline setup docs, tree flag, pyenv migration) and declined 5 problematic PRs (regressions, breaking changes, duplicates).
 - Added offline setup documentation for restricted network environments.
+- Implemented `download_wheels.sh` script and OFFLINE_WHEELS support for offline tests.
 - Completed systematic PR review and cleanup: processed all open PRs (13 total), closed duplicates and problematic PRs, maintained clean repository state.
 - Fixed `run_all.sh` so it initializes pyenv when run in a non-interactive shell.
 - Completed systematic review of PRs #94-#97: merged PR #97 (pyenv initialization fix) and rejected PRs #94-#96 (all attempted to revert the pyenv improvements).
@@ -22,7 +23,6 @@
 - Enhance console logs using `rich.tree` so run progress is shown as a clear tree.
 - Verify `run_all.sh` smoke test passes after updating dependencies.
 - Revise setup or CI to ensure required packages like `rich` install reliably without manual intervention.
-- Bundle prebuilt wheels or configure a local PyPI mirror so `make test` can run without internet access.
 - Apply the `deactivate` to `pyenv deactivate` fix from rejected PR #96 to `setup.sh`.
 
 ## Status

--- a/scripts/download_wheels.sh
+++ b/scripts/download_wheels.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Download all required wheels for offline installation
+# Usage: ./scripts/download_wheels.sh [wheel_dir]
+
+set -e
+
+WHEEL_DIR=${1:-wheels}
+mkdir -p "$WHEEL_DIR"
+
+pip download -d "$WHEEL_DIR" -r requirements.txt
+if [ -f requirements-py311.txt ]; then
+    pip download -d "$WHEEL_DIR" -r requirements-py311.txt
+fi
+if [ -f requirements-py310.txt ]; then
+    pip download -d "$WHEEL_DIR" -r requirements-py310.txt || true
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -141,10 +141,17 @@ install_env_tpa_deps() {
     # Upgrade pip first
     pip install --upgrade pip
 
-    if [ -f requirements-py311.txt ]; then
-        pip install --only-binary=:all: -r requirements-py311.txt
+    # Use offline wheels if OFFLINE_WHEELS is set and directory exists
+    if [ -n "$OFFLINE_WHEELS" ] && [ -d "$OFFLINE_WHEELS" ]; then
+        PIP_ARGS="--no-index --find-links=$OFFLINE_WHEELS"
     else
-        pip install --only-binary=:all: -r requirements.txt
+        PIP_ARGS=""
+    fi
+
+    if [ -f requirements-py311.txt ]; then
+        pip install $PIP_ARGS --only-binary=:all: -r requirements-py311.txt
+    else
+        pip install $PIP_ARGS --only-binary=:all: -r requirements.txt
     fi
 
     pyenv deactivate
@@ -165,14 +172,21 @@ install_env_as_deps() {
     # Upgrade pip first
     pip install --upgrade pip
 
+    # Use offline wheels if OFFLINE_WHEELS is set and directory exists
+    if [ -n "$OFFLINE_WHEELS" ] && [ -d "$OFFLINE_WHEELS" ]; then
+        PIP_ARGS="--no-index --find-links=$OFFLINE_WHEELS"
+    else
+        PIP_ARGS=""
+    fi
+
     if [ "$PYTHON_MINOR" -ge 11 ]; then
         log_warning "Auto-Sklearn 0.15.0 is incompatible with Python $PYTHON_MINOR; installing base stack only"
-        pip install --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
+        pip install $PIP_ARGS --only-binary=:all: numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
     else
         if [ -f requirements-py310.txt ]; then
-            pip install --only-binary=:all: -r requirements-py310.txt
+            pip install $PIP_ARGS --only-binary=:all: -r requirements-py310.txt
         else
-            pip install --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
+            pip install $PIP_ARGS --only-binary=:all: auto-sklearn==0.15.0 numpy pandas scikit-learn==1.4.2 matplotlib seaborn rich joblib
         fi
     fi
 


### PR DESCRIPTION
## Summary
- fix makefile indentation
- add download_wheels.sh script
- support OFFLINE_WHEELS in setup.sh to install packages without internet
- document offline setup in README
- update TODO to mark offline wheel bundling as done

## Testing
- `make test` *(fails: `pyenv: no such command 'virtualenv'`)*

------
https://chatgpt.com/codex/tasks/task_b_684cca9a3f088330bf961e094617c65b