### PR TITLE
Implement Python 3.10 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ using the orchestrator:
 pyenv activate automl-py311
 ```
 
+The script prefers Python 3.11 but will run with Python 3.10 if 3.11 is not
+available. In that case the Auto-Sklearn environment is enabled automatically
+and Python 3.11 is installed via `pyenv` for TPOT and AutoGluon.
+
 If you prefer to manage the environment yourself, install the required packages first:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - Fixed Makefile indentation issues to resolve "missing separator" errors (learned from rejected PRs).
 - Added offline wheel installation documentation to README.md (learned from rejected PRs).
 - Enhanced TPOT parameter validation (learned from rejected PRs).
+- Implemented Python 3.10 graceful handling in setup.sh without reverting pyenv initialization.
 
 ## Remaining Action Items
 
@@ -32,7 +33,6 @@
 
 ## New Action Items (Based on Team Feedback)
 
-- Implement Python 3.10 graceful handling in setup.sh without reverting pyenv initialization
 - Implement rich.tree console logging enhancement without reverting pyenv initialization  
 - Fix Makefile indentation issues properly without reverting other changes
 - Add TPOT parameter validation improvements without reverting pyenv initialization

--- a/setup.sh
+++ b/setup.sh
@@ -39,12 +39,16 @@ check_system() {
         log_warning "This script is optimized for Linux. Continuing anyway..."
     fi
     
-    # Check for available Python versions (strictly enforce 3.11)
+    # Check for available Python versions, prefer 3.11 but allow 3.10
     if command -v python3.11 &> /dev/null; then
         PYTHON_CMD="python3.11"
-        log_success "Found Python 3.11 (required)"
+        log_success "Found Python 3.11"
+    elif command -v python3.10 &> /dev/null; then
+        PYTHON_CMD="python3.10"
+        ENABLE_AS=true
+        log_warning "Python 3.11 not found. Using Python 3.10 instead. Some features may be limited."
     else
-        log_error "Python 3.11 is required but not found. Please install Python 3.11 before running this setup script."
+        log_error "Python 3.10 or higher is required but neither python3.11 nor python3.10 was found."
         log_info "For Ubuntu/Debian: sudo apt install python3.11 python3.11-venv python3.11-dev"
         log_info "For Arch: sudo pacman -S python311"
         exit 1


### PR DESCRIPTION
## Summary
- add Python 3.10 fallback logic in setup.sh
- document Python 3.10 support in README
- mark the TODO item as completed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ccc83764c8330bb90465e59b48b61