### PR TITLE
Add optimization results doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,5 @@ ensuring they persist between runs.
 
 This project is licensed under the [MIT License](LICENSE).
 
+
+See [RESULTS.md](RESULTS.md) for example optimization runs and metrics.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,39 @@
+# Optimization Strategies and Results
+
+This document summarizes the current optimization approach used in the AutoML orchestrator and the results obtained on the provided datasets.
+
+## Optimization Strategy
+
+1. **Multiple Engine Competition** – Every run invokes **Auto-Sklearn**, **TPOT** and **AutoGluon**. If a library is missing, the wrapper falls back to a simple `LinearRegression` model so the orchestrator can still produce a baseline result.
+2. **Time Budget** – Each engine receives the same wall-clock time limit. The examples below use `--time 5` (five seconds) to keep the runs lightweight.
+3. **Cross‑Validation** – The orchestrator evaluates each engine using **5×3 repeated k‑fold CV**. The mean R² score across folds selects the champion model.
+4. **Hold‑out Evaluation** – After training, the champion model is tested on a 20% hold‑out split to report generalization performance.
+
+## Dataset 1 Results
+
+Command:
+```bash
+python orchestrator.py --data DataSets/1/D1-Predictors.csv \
+  --target DataSets/1/D1-Targets.csv --all --time 5 --no-ensemble
+```
+Summary (from `metrics.json`):
+- Hold‑out R²: **-0.9201**
+- Hold‑out RMSE: **0.0031**
+- Hold‑out MAE: **0.0023**
+- TPOT and AutoGluon produced identical CV results because both fell back to `LinearRegression`; Auto‑Sklearn was unavailable.
+
+## Dataset 2 Results
+
+Command:
+```bash
+python orchestrator.py --data DataSets/2/D2-Predictors.csv \
+  --target DataSets/2/D2-Targets.csv --all --time 5 --no-ensemble
+```
+Summary (from `metrics.json`):
+- Hold‑out R²: **0.9600**
+- Hold‑out RMSE: **0.0005**
+- Hold‑out MAE: **0.0004**
+- The champion model again came from the TPOT wrapper with a fallback `LinearRegression` pipeline.
+
+All artifacts for each run are stored under `05_outputs/<dataset_name>/<timestamp>/`. The directory tree can be printed with the `--tree` flag to verify which files were generated.
+


### PR DESCRIPTION
## Summary
- document optimization strategy and results in new RESULTS.md
- link RESULTS.md from README
- include sample runs on datasets 1 and 2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cd29454988330ad859d8128bb1a88