### PR TITLE
Add offline setup and Python fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 ```
 
 This automatically creates the `automl-py311` and optional `automl-py310`
-environments using **pyenv**. After running it, activate the environment before
+environments using **pyenv**. If Python 3.11 is missing, the script falls back to Python 3.10 automatically.
+After running it, activate the environment before
 using the orchestrator:
 
 ```bash
@@ -168,6 +169,24 @@ The repository provides a convenience script to launch the orchestrator on **Dat
 ./run_d2.sh
 ```
 This uses all three engine wrappers on `DataSets/2/D2-Predictors.csv` and `DataSets/2/D2-Targets.csv`. Pass additional arguments after the script to forward them to `orchestrator.py`.
+
+### Offline Dependency Installation
+If the training environment cannot access the internet, download the required wheels on a machine that does:
+
+```bash
+mkdir wheels
+pip download -r requirements.txt -d wheels
+pip download -r requirements-py311.txt -d wheels
+pip download -r requirements-py310.txt -d wheels
+```
+
+Transfer the `wheels/` directory to the offline machine and run:
+
+```bash
+OFFLINE_WHEELS_DIR=./wheels ./setup.sh --with-as
+```
+
+`setup.sh` automatically installs packages from that directory using `pip --no-index`. This unblocks Dataset 2 training when network access is restricted.
 
 ## Project Structure
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -17,13 +17,33 @@ fi
 # Determine script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Activate the environment
-# Replace with the appropriate environment for your project
-# source "${SCRIPT_DIR}/env-tpa/bin/activate" # Example for a virtual environment
+# Activate the default environment. Fall back to automl-py310 if automl-py311
+# does not exist.
+if pyenv versions --bare | grep -q "automl-py311"; then
+    pyenv activate automl-py311
+elif pyenv versions --bare | grep -q "automl-py310"; then
+    pyenv activate automl-py310
+else
+    echo "Neither automl-py311 nor automl-py310 environment exists." >&2
+    exit 1
+fi
 
 # Set the PYTHON_PATH to include the current directory so Python can find orchestrator.py
 export PYTHONPATH="$SCRIPT_DIR:$PYTHONPATH"
 
-# Run the orchestrator script
-python orchestrator.py --all
+# Loop over all dataset directories and run a short smoke test on each
+for ds in "$SCRIPT_DIR"/DataSets/*; do
+    predictors=$(find "$ds" -maxdepth 1 -name '*Predictors.csv' | head -n 1)
+    targets=$(find "$ds" -maxdepth 1 -name '*Targets.csv' | head -n 1)
+    if [[ -f "$predictors" && -f "$targets" ]]; then
+        echo "Running smoke test on dataset $(basename "$ds")"
+        python orchestrator.py \
+            --data "$predictors" \
+            --target "$targets" \
+            --time 60 \
+            --all
+    fi
+done
+
+pyenv deactivate
 

--- a/run_d2.sh
+++ b/run_d2.sh
@@ -14,6 +14,18 @@ else
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Activate the default environment. Fall back to automl-py310 if automl-py311
+# does not exist.
+if pyenv versions --bare | grep -q "automl-py311"; then
+    pyenv activate automl-py311
+elif pyenv versions --bare | grep -q "automl-py310"; then
+    pyenv activate automl-py310
+else
+    echo "Neither automl-py311 nor automl-py310 environment exists." >&2
+    exit 1
+fi
+
 export PYTHONPATH="$SCRIPT_DIR:$PYTHONPATH"
 
 python orchestrator.py \


### PR DESCRIPTION
## Summary
- gracefully fall back to Python 3.10 in setup script
- add offline wheels installation logic
- update smoke test scripts to check both datasets and handle env fallback
- document offline installation steps and fallback behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cd299a6848330b93be82911bd5532