### PR TITLE
Enhance logging and TPOT validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-PHONY += setup test clean
+.PHONY: setup test clean
 
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
-	@echo "Cleanup complete." 
+	@echo "Cleanup complete."

--- a/tests/test_tpot_validation.py
+++ b/tests/test_tpot_validation.py
@@ -1,0 +1,42 @@
+import importlib
+import importlib.util
+import os
+import types
+import sys
+import pytest
+
+
+def load_module(monkeypatch):
+    stub_names = ['pandas', 'rich', 'rich.console', 'rich.tree', 'sklearn', 'sklearn.base', 'components.base']
+    for name in stub_names:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+    sys.modules['rich.console'].Console = type('Console', (), {'__init__': lambda self, *a, **k: None})
+    sys.modules['rich.tree'].Tree = type('Tree', (), {})
+    sys.modules['sklearn.base'].BaseEstimator = object
+    sys.modules['components.base'].BaseEngine = object
+
+    spec = importlib.util.spec_from_file_location(
+        'engines.tpot_wrapper',
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), 'engines', 'tpot_wrapper.py'),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['engines.tpot_wrapper'] = module
+    sys.modules.setdefault('engines', types.ModuleType('engines')).tpot_wrapper = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_tpot_parameters(monkeypatch):
+    mod = load_module(monkeypatch)
+
+    with pytest.raises(ValueError):
+        mod._validate_tpot_parameters(["BadModel"], [], "r2")
+    with pytest.raises(ValueError):
+        mod._validate_tpot_parameters([], ["BadPreprocessor"], "r2")
+    with pytest.raises(ValueError):
+        mod._validate_tpot_parameters([], [], "not_a_metric")
+
+    mod._validate_tpot_parameters(["Ridge"], ["StandardScaler"], "r2")
+
+


### PR DESCRIPTION
## Summary
- fix Makefile tabs for commands
- add a summary tree to orchestrator console output
- improve TPOT parameter validation and add tests

## Testing
- `pytest -q`
- `make test` *(fails: pyenv: no such command `virtualenv`)*

------
https://chatgpt.com/codex/tasks/task_b_684cd2a52c708330810c2302465d3ae3