### PR TITLE
Stub feature engineering in integration tests

### DIFF
--- a/tests/test_integration_engines.py
+++ b/tests/test_integration_engines.py
@@ -59,6 +59,15 @@ def load_orchestrator(monkeypatch):
     metrics.r2_score = lambda *a, **k: 0
     monkeypatch.setitem(sys.modules, "sklearn.metrics", metrics)
 
+    monkeypatch.setitem(sys.modules, "scripts", types.ModuleType("scripts"))
+    fe_mod = types.ModuleType("scripts.feature_engineering")
+    def engineer_features(X):
+        return X, types.SimpleNamespace(
+            named_steps={"pca": types.SimpleNamespace(n_components_=1)}
+        )
+    fe_mod.engineer_features = engineer_features
+    monkeypatch.setitem(sys.modules, "scripts.feature_engineering", fe_mod)
+
     data_loader = types.ModuleType("scripts.data_loader")
     def load_data(*a, **k):
         return DummyX([1]), DummyY([1])
@@ -86,6 +95,9 @@ def load_orchestrator(monkeypatch):
 
     pickle_stub = types.ModuleType("pickle")
     pickle_stub.dump = lambda *a, **k: None
+    pickle_stub.Pickler = type("Pickler", (), {})
+    pickle_stub.loads = lambda *a, **k: None
+    pickle_stub.load = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "pickle", pickle_stub)
 
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_tree_output.py
+++ b/tests/test_tree_output.py
@@ -64,6 +64,15 @@ def load_orchestrator(monkeypatch, printed):
     metrics.r2_score = lambda *a, **k: 0
     monkeypatch.setitem(sys.modules, "sklearn.metrics", metrics)
 
+    monkeypatch.setitem(sys.modules, "scripts", types.ModuleType("scripts"))
+    fe_mod = types.ModuleType("scripts.feature_engineering")
+    def engineer_features(X):
+        return X, types.SimpleNamespace(
+            named_steps={"pca": types.SimpleNamespace(n_components_=1)}
+        )
+    fe_mod.engineer_features = engineer_features
+    monkeypatch.setitem(sys.modules, "scripts.feature_engineering", fe_mod)
+
     data_loader = types.ModuleType("scripts.data_loader")
     def load_data(*a, **k):
         return DummyX(), DummyY([1])
@@ -91,6 +100,9 @@ def load_orchestrator(monkeypatch, printed):
 
     pickle_stub = types.ModuleType("pickle")
     pickle_stub.dump = lambda *a, **k: None
+    pickle_stub.Pickler = type("Pickler", (), {})
+    pickle_stub.loads = lambda *a, **k: None
+    pickle_stub.load = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "pickle", pickle_stub)
 
 


### PR DESCRIPTION
## Summary
- mock `scripts.feature_engineering` in integration tests
- stub `pickle` with required attributes for multiprocessing

## Testing
- `pytest tests/test_integration_engines.py tests/test_tree_output.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684cd942b5208330bb14f53714b86e7b