### PR TITLE
Fix PHONY declaration and tab indentation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-PHONY += setup test clean
+.PHONY: setup test clean
 
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
 	@echo "Cleanup complete." 


### PR DESCRIPTION
## Summary
- correct `.PHONY` declaration
- fix leading tabs for all target commands

## Testing
- `make setup` *(fails: pyenv no such command 'virtualenv')*
- `make clean`

------
https://chatgpt.com/codex/tasks/task_b_684cd94189408330bb2ec240eb804006