### PR TITLE
Fix environment deactivation in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -292,7 +292,7 @@ print(f'  - NumPy version: {np.__version__}')
 print(f'  - Pandas version: {pd.__version__}')
 "
     fi
-    deactivate
+    pyenv deactivate
     
     log_success "All environments tested successfully"
 }


### PR DESCRIPTION
## Summary
- exit testing environment correctly in setup.sh with `pyenv deactivate`

## Testing
- `shellcheck -S error setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_684cd9405f6883309a6952d303447090