### PR TITLE
Add offline wheel option and richer logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-PHONY += setup test clean
+.PHONY: setup test clean
 
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
 	@bash setup.sh # Rerun setup.sh to trigger post_setup_check. Placeholder for actual tests
-	# In a real scenario, you would have a `python -m pytest` or similar here
+# In a real scenario, you would have a `python -m pytest` or similar here
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
-	@echo "Cleanup complete." 
+	@echo "Cleanup complete."

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -841,13 +841,17 @@ def _cli() -> None:
     logger.addHandler(file_handler)
 
     console.log("[bold green]Starting AutoML Orchestrator Run[/bold green]")
-    start_time = time.perf_counter() # Record the start time of the run
-    console.log(f"  Dataset: {args.data}")
-    console.log(f"  Target: {args.target}")
-    console.log(f"  Time Limit per Engine: {args.time} seconds")
-    console.log(f"  Evaluation Metric: {args.metric}")
-    console.log(f"  Selected Engines: {', '.join(selected_engines)}")
-    console.log(f"  Artifacts Directory: {run_dir}")
+    start_time = time.perf_counter()  # Record the start time of the run
+    config_tree = Tree("[bold magenta]Run Configuration[/bold magenta]")
+    config_tree.add(f"[cyan]Data:[/cyan] {args.data}")
+    config_tree.add(f"[cyan]Target:[/cyan] {args.target}")
+    config_tree.add(f"[cyan]Time Limit:[/cyan] {args.time}s")
+    config_tree.add(f"[cyan]Metric:[/cyan] {args.metric}")
+    engines_node = config_tree.add("[cyan]Engines[/cyan]")
+    for eng in selected_engines:
+        engines_node.add(eng)
+    config_tree.add(f"[cyan]Artifacts:[/cyan] {run_dir}")
+    console.print(config_tree)
 
     # Load data
     try:


### PR DESCRIPTION
## Summary
- set up pyenv in `setup.sh` and allow fallback from Python 3.10 to 3.11
- support offline wheel installs via `--offline` flag
- fix Makefile indentation
- log run configuration as a Rich tree

## Testing
- `make test` *(fails: pyenv command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cd912488c8330a182168994ec3b5d