### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHONY += setup test clean
 setup:
 	@echo "Setting up the AutoML Harness environment..."
 	@bash setup.sh
-       @echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
+	@echo "Setup complete. Remember to activate your environment: pyenv activate automl-py311"
 
 test:
 	@echo "Running tests (not yet implemented - will run post-setup checks)..."
@@ -12,7 +12,7 @@ test:
 
 clean:
 	@echo "Cleaning up generated files and environments..."
-       @rm -rf env-as env-tpa 05_outputs
+	@rm -rf env-as env-tpa 05_outputs
 	@find . -name "__pycache__" -exec rm -rf {} + || true
 	@find . -name ".pytest_cache" -exec rm -rf {} + || true
 	@echo "Cleanup complete." 


### PR DESCRIPTION
## Summary
- fix indentation with tabs in `Makefile`

## Testing
- `make test` *(fails: pyenv: no such command `virtualenv`)*

------
https://chatgpt.com/codex/tasks/task_b_684cdce7f5e88330ad54d3e34f37817c