### PR TITLE
Update logstash async requirement

### DIFF
--- a/requirements-py310.txt
+++ b/requirements-py310.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==4.0.2

--- a/requirements-py311.txt
+++ b/requirements-py311.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ autogluon.tabular[all]==1.3.1
 psutil==5.9.8
 xgboost==2.0.3
 lightgbm==4.3.0
-python-logstash-async==2.9.0
+python-logstash-async==4.0.2


### PR DESCRIPTION
## Summary
- fix python-logstash-async version in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684cd820d81c83308e43f8458adcdd28